### PR TITLE
fix: decode array-wrapped Fankit gallery image URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Recovered official wallpapers whose Fankit gallery entries wrap the image URL in a single-element array instead of a plain string, restoring most of the official wallpaper catalog instead of only the newest entries.
+
 ## [0.4.1]
 
 ### Changed

--- a/Sources/ArknightsClient/Features/Customization/Presets/Models/PresetCatalogModels.swift
+++ b/Sources/ArknightsClient/Features/Customization/Presets/Models/PresetCatalogModels.swift
@@ -84,5 +84,10 @@ private func decodeStringOrInt(
 	if let value = try? container.decodeIfPresent(Int.self, forKey: key) {
 		return String(value)
 	}
+	// Older Fankit gallery entries wrap the image URL in a single-element array
+	// instead of returning it as a plain string.
+	if let values = try? container.decodeIfPresent([String].self, forKey: key) {
+		return values.first
+	}
 	return nil
 }


### PR DESCRIPTION
## Problem

The wallpaper gallery only showed 33 of the 206 available official wallpapers from Yostar's Fankit API.

## Root cause

Yostar's gallery API returns `image1`/`smallImage` in two different formats depending on entry age:
- The ~33 newest entries return a plain string: `"image1": "https://.../file.png"`
- The ~173 older entries return a single-element array: `"image1": ["https://.../file.png"]`

`YostarGalleryRow`'s tolerant decoder (`decodeStringOrInt`) only tried decoding the field as `String` or `Int`. For the array-typed entries, both attempts failed, silently returning `nil` for `image1` and `smallImage`, so `refreshWallpapersFromRemote()` skipped them via its `guard let rawURL = row.image1 ?? row.smallImage ... else { continue }`.

## Fix

Extended `decodeStringOrInt` to also try decoding a `[String]` and use its first element when present.

## Verification

Built and ran the app locally; after clearing the preset cache, the gallery now loads all 206 wallpapers instead of 33.
