### PR TITLE
fix: enlarge undersized click areas on custom buttons

### DIFF
--- a/Sources/ArknightsClient/Features/Audio/UI/HUD/MusicHUDPill.swift
+++ b/Sources/ArknightsClient/Features/Audio/UI/HUD/MusicHUDPill.swift
@@ -46,6 +46,8 @@ struct MusicHUDPill: View {
 							.contentTransition(.symbolEffect(.replace))
 							.accessibilityHidden(true)
 					}
+					.padding(.horizontal, isExpanded ? 14 : 12)
+					.frame(height: isExpanded ? nil : AppConstants.Music.collapsedPlayerHeight)
 					.contentShape(Rectangle())
 				}
 				.buttonStyle(.plain)
@@ -101,11 +103,11 @@ struct MusicHUDPill: View {
 							action: model.openCurrentMusicURL
 						)
 					}
+					.padding(.horizontal, 14)
 					.frame(maxWidth: .infinity, alignment: .leading)
 					.transition(expandedContentTransition)
 				}
 			}
-			.padding(.horizontal, isExpanded ? 14 : 12)
 			.padding(.vertical, isExpanded ? 11 : 0)
 			.frame(
 				width: isExpanded ? AppConstants.Music.expandedPlayerWidth : nil,

--- a/Sources/ArknightsClient/Features/Launcher/Home/Components/VersionHUDPill.swift
+++ b/Sources/ArknightsClient/Features/Launcher/Home/Components/VersionHUDPill.swift
@@ -35,6 +35,8 @@ struct VersionHUDPill: View {
 							.accessibilityHidden(true)
 					}
 				}
+				.padding(.horizontal, isExpanded ? 14 : 12)
+				.frame(height: isExpanded ? nil : AppConstants.Music.collapsedPlayerHeight)
 				.contentShape(Rectangle())
 			}
 			.buttonStyle(.plain)
@@ -57,10 +59,10 @@ struct VersionHUDPill: View {
 					)
 					.disabled(cannotCheck)
 				}
+				.padding(.horizontal, 14)
 				.transition(expandedContentTransition)
 			}
 		}
-		.padding(.horizontal, isExpanded ? 14 : 12)
 		.padding(.vertical, isExpanded ? 11 : 0)
 		.frame(
 			width: isExpanded ? AppConstants.HUD.expandedVersionWidth : nil,

--- a/Sources/ArknightsClient/Shared/UI/Components/ThemedInputSurface.swift
+++ b/Sources/ArknightsClient/Shared/UI/Components/ThemedInputSurface.swift
@@ -15,11 +15,13 @@ private struct ThemedInputSurfaceModifier: ViewModifier {
 					in: .rect(cornerRadius: 10)
 				)
 				.overlay { focusBorder }
+				.contentShape(inputShape)
 		} else {
 			content
 				.background(accentColor.opacity(isFocused ? 0.12 : 0.06), in: inputShape)
 				.background(.ultraThinMaterial, in: inputShape)
 				.overlay { focusBorder }
+				.contentShape(inputShape)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- `ThemedInputSurface` (used by `ThemedTextField` and menu-style dropdown labels) had no `contentShape`, so clicks near the padded edge of the surface missed the control.
- The Now Playing and version-number HUD pills applied their outer padding at the container level, outside the toggle button's own `contentShape` — only the inner icon/text row was actually clickable, not the visible padded pill.

## Fix
Moves the padding inside the button itself (and adds an explicit height for the collapsed pill state) so `contentShape` covers the whole visible control, not just its inner content.

## Test plan
- [x] `swift build` compiles clean
- [ ] Manually verify: click near the edge of the search field / dropdown labels registers
- [ ] Manually verify: click near the edge of the collapsed Now Playing / version pills toggles them