### PR TITLE
fix: follow symbolic-link ancestors during app storage migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to this project are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Followed symbolic-link ancestors (for example, a `Games` folder relocated to external storage) during app storage migration instead of failing launcher startup outright, while still rejecting a symlinked migration endpoint itself.
+
 ## [0.5.0] - 2026-09-03
 
 ### Added

--- a/Sources/ArknightsClient/Shared/Persistence/AppStorageMigrator.swift
+++ b/Sources/ArknightsClient/Shared/Persistence/AppStorageMigrator.swift
@@ -15,7 +15,8 @@ enum AppStorageMigrationError: Error, Equatable, Sendable, CustomStringConvertib
 
 	var description: String {
 		switch self {
-		case .unsafeNode(let url): "Unsafe non-directory or symbolic-link node: \(url.path)"
+		case .unsafeNode(let url):
+			"Unsafe node: not a directory, or a broken or non-directory symbolic link: \(url.path)"
 		case .conflictingDirectories(let old, let new):
 			"Both legacy and current directories exist: \(old.path) and \(new.path)"
 		case .cannotInspect(let url, let error):
@@ -129,11 +130,14 @@ enum AppStorageMigrator {
 		]
 	}
 
-	private static func nodeState(at url: URL) throws -> NodeState {
+	private static func nodeState(at url: URL, followSymbolicLinks: Bool = false) throws
+		-> NodeState
+	{
 		var status = stat()
 		let result = url.withUnsafeFileSystemRepresentation { representation -> Int32 in
 			guard let representation else { return -1 }
-			return lstat(representation, &status)
+			return followSymbolicLinks
+				? stat(representation, &status) : lstat(representation, &status)
 		}
 		guard result == 0 else {
 			let error = errno
@@ -146,21 +150,27 @@ enum AppStorageMigrator {
 		return .directory
 	}
 
+	// Walks down to `url` component by component. Every ancestor may be a symbolic link that
+	// resolves to a real directory — for example, a legacy folder relocated to external
+	// storage behind a symlink to save disk space — but `url` itself, the actual migration
+	// endpoint, must be a genuine directory so `moveItem` never operates through an
+	// unexpected indirection at the boundary we're about to touch.
 	private static func validatePathComponents(of url: URL, under root: URL) throws {
 		let root = root.standardizedFileURL
 		let target = url.standardizedFileURL
 		guard target.pathComponents.starts(with: root.pathComponents) else {
 			throw AppStorageMigrationError.unsafeNode(target)
 		}
-		switch try nodeState(at: root) {
+		switch try nodeState(at: root, followSymbolicLinks: true) {
 		case .absent: return
 		case .directory: break
 		}
-		let relativeComponents = target.pathComponents.dropFirst(root.pathComponents.count)
+		let relativeComponents = Array(target.pathComponents.dropFirst(root.pathComponents.count))
 		var component = root
-		for name in relativeComponents {
+		for (index, name) in relativeComponents.enumerated() {
 			component.append(path: name)
-			switch try nodeState(at: component) {
+			let isFinalComponent = index == relativeComponents.count - 1
+			switch try nodeState(at: component, followSymbolicLinks: !isFinalComponent) {
 			case .absent: return
 			case .directory: continue
 			}

--- a/Tests/ArknightsClientTests/Shared/Persistence/AppStorageMigratorTests.swift
+++ b/Tests/ArknightsClientTests/Shared/Persistence/AppStorageMigratorTests.swift
@@ -98,6 +98,45 @@ func appStorageMigratorRejectsSymbolicLinkSources() throws {
 }
 
 @Test
+func appStorageMigratorFollowsASymbolicLinkAncestorToTheActualLegacyDirectory() throws {
+	// Mirrors relocating "Games" to external storage behind a symlink to save disk space: the
+	// symlink is an ancestor of the legacy path, not the migration endpoint itself, and should
+	// be followed rather than rejected outright.
+	let root = FileManager.default.temporaryDirectory
+		.appending(
+			path: "AppStorageMigratorSymlinkAncestorTests.\(UUID().uuidString)",
+			directoryHint: .isDirectory)
+	defer { try? FileManager.default.removeItem(at: root) }
+	let paths = AppPaths(
+		applicationSupportDirectory: root.appending(path: "Support"),
+		cachesDirectory: root.appending(path: "Caches"),
+		libraryDirectory: root.appending(path: "Library")
+	)
+	let fileManager = FileManager.default
+	let relocatedGames = root.appending(path: "Relocated-Games", directoryHint: .isDirectory)
+	let relocatedLegacyGame = relocatedGames.appending(path: "Arknights-Global")
+	try fileManager.createDirectory(at: relocatedLegacyGame, withIntermediateDirectories: true)
+	try Data("game".utf8).write(to: relocatedLegacyGame.appending(path: "marker"))
+
+	let games = paths.applicationSupportRoot.appending(path: "Games")
+	try fileManager.createDirectory(
+		at: paths.applicationSupportRoot, withIntermediateDirectories: true)
+	try fileManager.createSymbolicLink(at: games, withDestinationURL: relocatedGames)
+
+	let legacyGame = games.appending(path: "Arknights-Global")
+	let result = try AppStorageMigrator.migrate(
+		paths: paths,
+		persistedInstallDirectories: [.global: legacyGame],
+		fileManager: fileManager
+	)
+
+	#expect(
+		fileManager.fileExists(
+			atPath: paths.gameInstall(for: .global).appending(path: "marker").path))
+	#expect(result.installDirectoriesToUpdate[.global] == paths.gameInstall(for: .global))
+}
+
+@Test
 func appStorageMigratorRejectsConflictsWithoutChangingEitherDirectory() throws {
 	let root = FileManager.default.temporaryDirectory
 		.appending(


### PR DESCRIPTION
## Summary

- The 0.5.0 app storage migration (`AppStorageMigrator`) used `lstat` for every component while walking down to a legacy directory, so any symlink anywhere in the path was rejected as `AppStorageMigrationError.unsafeNode` — this crashes launcher startup entirely (nothing past migration runs, including the update check).
- A common way this happens: relocating the `Games` folder to external storage behind a symlink to save disk space, since game installs and Wine prefixes can run into the tens of GB. That's exactly the setup that hit this in practice.
- Fix: ancestor components are now inspected with `stat` (following symlinks) so a relocated directory is recognized as usable while walking down to the target. The actual migration endpoint itself — the directory that's really being moved — still uses `lstat` and is rejected if it's a symlink, preserving the existing protection (and existing test `appStorageMigratorRejectsSymbolicLinkSources`) against migrating through an unexpected indirection at the boundary being moved.

## Note

Because the migration destination is always a fixed path under `applicationSupportRoot`, migrating a legacy directory that sits behind a symlink to another volume will still physically move that data onto the volume containing Application Support (`FileManager.moveItem` falls back to copy+remove across volumes). That preserves today's migration semantics — the app has no concept of a chosen external install location — so it's out of scope here, but users who relocated storage externally may want to re-relocate the migrated directory afterward.

## Test plan

- [x] `just check` — full local check suite (lint, unit tests, Python tests) passes, 332/332 Swift tests.
- [x] Added `appStorageMigratorFollowsASymbolicLinkAncestorToTheActualLegacyDirectory`, reproducing a `Games`-folder-relocated-via-symlink setup; migration now succeeds and updates the persisted install directory as expected.
- [x] Verified the existing `appStorageMigratorRejectsSymbolicLinkSources` (symlinked migration endpoint itself) still passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UyT5JbE6Vxh1QYaDwsxwh