### PR TITLE
fix: look up WallpaperTags.json through the packaged resource path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to this project are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Stopped the packaged app from crashing as soon as the preset gallery loaded wallpaper tags, by looking up the bundled `WallpaperTags.json` the same way other packaged resources already do instead of through the SwiftPM-only resource bundle.
+
 ## [0.5.0] - 2026-09-03
 
 ### Added

--- a/Sources/ArknightsClient/Features/Customization/Presets/Models/PresetCatalogModels.swift
+++ b/Sources/ArknightsClient/Features/Customization/Presets/Models/PresetCatalogModels.swift
@@ -136,8 +136,12 @@ enum WallpaperTagCatalog {
 	}
 
 	private static func load() -> [String: [String]] {
+		// `WallpaperTags.json` is a `.copy()` package resource, so the packaged app copies it
+		// flat into `Contents/Resources` rather than into the SwiftPM `Bundle.module` bundle —
+		// the same pattern `AppIconRenderer+Avatars` uses for its own `.copy()` resources.
 		guard
-			let url = Bundle.module.url(forResource: "WallpaperTags", withExtension: "json"),
+			let url = Bundle.main.url(forResource: "WallpaperTags", withExtension: "json")
+				?? AppResourceBundle.bundle.url(forResource: "WallpaperTags", withExtension: "json"),
 			let data = try? Data(contentsOf: url),
 			let manifest = try? JSONDecoder().decode(WallpaperTagManifest.self, from: data),
 			manifest.schemaVersion == 1


### PR DESCRIPTION
## Summary

- The packaged `.app` crashes (`EXC_BREAKPOINT`/`SIGTRAP`, `_assertionFailure` inside `Bundle.module`'s static initializer) the instant the preset gallery computes wallpaper search suggestions — i.e. as soon as you open Artwork.
- Root cause: `WallpaperTagCatalog.load()` reads `WallpaperTags.json` via `Bundle.module`, but that resource is declared `.copy("Resources/WallpaperTags.json")` in `Package.swift`, and `scripts/build_app.py` copies every `.copy()` resource flat into `Contents/Resources` (see `copied_resource_source_paths`), not into the SwiftPM-generated `ArknightsClient_ArknightsClient.bundle`. In the shipped app, that generated bundle folder doesn't exist at all, so evaluating `Bundle.module` unconditionally `fatalError`s.
- This only ever showed up in the packaged release: `swift build`/`swift test`/`swift run` all resolve `Bundle.module` correctly against `.build/.../ArknightsClient_ArknightsClient.bundle`, masking the packaging mismatch in every normal dev workflow.
- Fix: look the resource up the same way `AppIconRenderer+Avatars` already does for its own `.copy()` resources (`GameIconBackground.png`, `OperatorIconFrame.svg`) — `Bundle.main` first (works in the packaged app), falling back to `AppResourceBundle.bundle` (works under `swift run`/`swift test`).

## Test plan

- [x] `just check` — 331/331 Swift tests pass.
- [x] Built the real release app (`just dev app`) and confirmed `Contents/Resources/ArknightsClient_ArknightsClient.bundle` does not exist in it (reproducing the crash's root cause directly, since `Bundle.module`'s fallback build-machine path also can't exist on a shipped app).
- [x] Confirmed `Bundle(path: <built .app>).url(forResource: "WallpaperTags", withExtension: "json")` (the exact lookup the fix performs as `Bundle.main` inside the running app) now resolves and reads the file successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UyT5JbE6Vxh1QYaDwsxwh