### PR TITLE
fix: restore search field tag pills lost during PR #61's merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to this project are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Restored the wallpaper search field's committed-tag pills (typing or picking a complete tag promotes it out of free text into a removable pill), which #61 implemented and described but lost during a merge conflict before release.
+
 ## [0.5.0] - 2026-09-03
 
 ### Added

--- a/Sources/ArknightsClient/Features/Customization/CustomizationStrings.swift
+++ b/Sources/ArknightsClient/Features/Customization/CustomizationStrings.swift
@@ -25,6 +25,7 @@ enum CustomizationStrings {
 	static let operatorTitle = LocalizedStringResource.Customization
 		.customizationGalleryOperatorTitle
 	static let searchLabel = LocalizedStringResource.Customization.customizationGallerySearchLabel
+	static let searchClear = LocalizedStringResource.Customization.customizationGallerySearchClear
 	static let searchSuggestionSelect = LocalizedStringResource.Customization
 		.customizationGallerySearchSuggestionSelect
 	static let wallpaperFilterAll = LocalizedStringResource.Customization
@@ -56,6 +57,10 @@ enum CustomizationStrings {
 
 	static func wallpaperApplyHelp(_ title: String) -> LocalizedStringResource {
 		.Customization.customizationGalleryWallpaperApplyHelp(title)
+	}
+
+	static func searchRemoveTag(_ tag: String) -> LocalizedStringResource {
+		.Customization.customizationGallerySearchRemoveTag(tag)
 	}
 
 	static func wallpaperFallbackTitle(_ number: Int) -> LocalizedStringResource {

--- a/Sources/ArknightsClient/Features/Customization/Presets/Models/WallpaperSearch.swift
+++ b/Sources/ArknightsClient/Features/Customization/Presets/Models/WallpaperSearch.swift
@@ -137,6 +137,40 @@ enum WallpaperSearch {
 		return terms.joined(separator: " ") + " "
 	}
 
+	/// Finds the longest trailing run of words in `query` that together spell out a complete
+	/// known tag — checking only the single last word would never recognize a multi-word tag
+	/// like "blue poison" (splitting on whitespace breaks it into "blue" and "poison" before
+	/// any lookup happens), so this tries the whole trailing phrase first and shrinks by one
+	/// word at a time until a match is found.
+	///
+	/// Returns the matched canonical tag and `query` with that trailing phrase removed (with a
+	/// trailing space preserved if anything remains before it), or `nil` if nothing matches.
+	static func trailingKnownTag(
+		in query: String, canonicalTagsByNormalizedForm: [String: String]
+	) -> (tag: String, remainingQuery: String)? {
+		let terms = query.split(whereSeparator: \.isWhitespace).map(String.init)
+		guard !terms.isEmpty else { return nil }
+
+		for wordCount in stride(from: terms.count, through: 1, by: -1) {
+			let phrase = terms.suffix(wordCount).joined(separator: " ")
+			guard let canonical = canonicalTagsByNormalizedForm[normalized(phrase)] else {
+				continue
+			}
+			let remainder = terms.dropLast(wordCount)
+			let remainingQuery = remainder.isEmpty ? "" : remainder.joined(separator: " ") + " "
+			return (canonical, remainingQuery)
+		}
+		return nil
+	}
+
+	/// Whether `tags` contains `tag` exactly (case/diacritic-insensitive) — committed tag
+	/// pills require an exact match by design, since a prefix match is what free-text terms
+	/// are for; a pill exists specifically to pin down one exact tag.
+	static func tagsContain(_ tags: [String], exactly tag: String) -> Bool {
+		let normalizedTag = normalized(tag)
+		return tags.contains { normalized($0) == normalizedTag }
+	}
+
 	/// Case- and diacritic-folded form of `value`, used for every comparison in this type.
 	///
 	/// Foundation's `.diacriticInsensitive` string options don't fold every accented letter —

--- a/Sources/ArknightsClient/Features/Customization/Presets/UI/PresetGalleryView+Search.swift
+++ b/Sources/ArknightsClient/Features/Customization/Presets/UI/PresetGalleryView+Search.swift
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import SwiftUI
+
+/// The wallpaper gallery's search bar and its committed-tag pills.
+extension PresetGalleryView {
+	// Every curated tag value keyed by its normalized form, computed once from the bundled
+	// manifest — lets us recover the properly-spelled tag (e.g. "młynar", not "mlynar") to
+	// display as a pill from whatever casing/diacritics the user actually typed, and doubles
+	// as the membership set for "is this query already a complete, known tag" checks.
+	private static let canonicalTagsByNormalizedForm: [String: String] = Dictionary(
+		WallpaperTagCatalog.shared.values.flatMap(\.self).map {
+			(WallpaperSearch.normalized($0), $0)
+		},
+		uniquingKeysWith: { first, _ in first }
+	)
+
+	// Pins the text field and tag pills to an identical content height so committing a tag
+	// never changes the search bar's overall height. Left to their own intrinsic sizes, a
+	// pill (caption lineHeight 13 + 6pt vertical padding = 19pt) is measurably taller than
+	// the text field (callout lineHeight 15pt), so the bar would visibly grow the instant
+	// the first tag pill appears.
+	private static let searchRowContentHeight: CGFloat = 18
+
+	var searchBar: some View {
+		HStack(spacing: 6) {
+			Image(systemName: "magnifyingglass")
+				.font(.caption)
+				.foregroundStyle(isSearchFieldFocused ? customization.accentColor : .secondary)
+				.accessibilityHidden(true)
+
+			if destination == .artwork {
+				ForEach(committedTags, id: \.self) { tag in tagPill(tag) }
+			}
+
+			TextField(L10n.string(destination.searchPlaceholder), text: $searchText)
+				.textFieldStyle(.plain)
+				.focused($isSearchFieldFocused)
+				.frame(height: Self.searchRowContentHeight)
+				.accessibilityLabel(L10n.string(CustomizationStrings.searchLabel))
+				.onKeyPress(.delete) {
+					// Backspace on an already-empty field pops the last pill — mirrors the
+					// familiar chip-input behavior from Mail's To: field or Gmail's search bar.
+					guard searchText.isEmpty, !committedTags.isEmpty else { return .ignored }
+					committedTags.removeLast()
+					return .handled
+				}
+
+			if !searchText.isEmpty || !committedTags.isEmpty {
+				// Deliberately not a `Button`: on macOS, a `Button` wrapping only an `Image`
+				// gets backed by a native control that hit-tests against the glyph's own
+				// rendered (opaque) pixels, ignoring any `.contentShape()` override — no
+				// frame or shape override on the label fixes that. A plain view with
+				// `.onTapGesture` uses SwiftUI's own gesture recognition instead, which
+				// does respect `.contentShape()` across its whole frame.
+				Image(systemName: "xmark.circle.fill")
+					.font(.callout)
+					.imageScale(.large)
+					.foregroundStyle(.secondary)
+					.frame(width: Self.searchRowContentHeight, height: Self.searchRowContentHeight)
+					.contentShape(Rectangle())
+					.onTapGesture {
+						searchText = ""
+						committedTags = []
+						lastAppliedSuggestionText = nil
+					}
+					.accessibilityAddTraits(.isButton)
+					.accessibilityLabel(L10n.string(CustomizationStrings.searchClear))
+			}
+		}
+		.font(.callout)
+		.padding(.horizontal, 10)
+		.padding(.vertical, 7)
+		.adaptiveGlassEffect(
+			tint: customization.accentColor.opacity(isSearchFieldFocused ? 0.16 : 0.08),
+			in: RoundedRectangle(cornerRadius: 10)
+		)
+		.overlay {
+			RoundedRectangle(cornerRadius: 10)
+				.strokeBorder(
+					isSearchFieldFocused
+						? customization.accentColor.opacity(0.72)
+						: LauncherVisuals.controlTint.opacity(0.16),
+					lineWidth: isSearchFieldFocused ? 1.5 : 1
+				)
+				.allowsHitTesting(false)
+		}
+		.keyboardFocusIndicator(
+			isFocused: isSearchFieldFocused, in: RoundedRectangle(cornerRadius: 8)
+		)
+		.onChange(of: searchText) { _, _ in promoteTrailingTagIfNeeded() }
+	}
+
+	private func tagPill(_ tag: String) -> some View {
+		HStack(spacing: 4) {
+			Text(tag)
+				.font(.caption.weight(.semibold))
+				.lineLimit(1)
+			// Deliberately not a `Button` — see the search bar's clear button for why a
+			// `Button` wrapping only an `Image` doesn't actually respect an enlarged
+			// `.contentShape()` on macOS. `.onTapGesture` does.
+			Image(systemName: "xmark")
+				.font(.system(size: 10, weight: .bold))
+				.frame(width: Self.searchRowContentHeight, height: Self.searchRowContentHeight)
+				.contentShape(Rectangle())
+				.onTapGesture {
+					committedTags.removeAll { $0 == tag }
+				}
+				.accessibilityAddTraits(.isButton)
+				.accessibilityLabel(L10n.string(CustomizationStrings.searchRemoveTag(tag)))
+		}
+		.padding(.leading, 8)
+		.padding(.trailing, 4)
+		.padding(.vertical, 3)
+		.background(customization.accentColor.opacity(0.22), in: .capsule)
+		.overlay(Capsule().strokeBorder(customization.accentColor.opacity(0.5), lineWidth: 1))
+		.frame(height: Self.searchRowContentHeight)
+	}
+
+	// Wallpapers must carry every committed tag pill exactly before the free-text query is even
+	// applied — otherwise a pill would just be one more prefix/substring term instead of pinning
+	// down that exact tag. Shared by the grid, the type filter, and suggestions so all three
+	// agree on which wallpapers are in play.
+	private var tagFilteredWallpapers: [PresetWallpaper] {
+		wallpapers.filter { wallpaper in
+			committedTags.allSatisfy {
+				WallpaperSearch.tagsContain(
+					WallpaperTagCatalog.tags(for: wallpaper.id), exactly: $0)
+			}
+		}
+	}
+
+	var filteredWallpapers: [PresetWallpaper] {
+		PresetCatalogSearch.wallpapers(
+			matching: searchText, category: selectedCategory, in: tagFilteredWallpapers)
+	}
+
+	var wallpaperTerms: [String] {
+		let categoryWallpapers = tagFilteredWallpapers.filter {
+			selectedCategory == nil || $0.category == selectedCategory
+		}
+		let committedNormalized = Set(committedTags.map(WallpaperSearch.normalized))
+		return PresetCatalogSearch.wallpaperSuggestions(
+			matching: searchText, in: categoryWallpapers
+		).filter { !committedNormalized.contains(WallpaperSearch.normalized($0)) }
+	}
+
+	// Promotes the just-completed trailing phrase of `searchText` into a tag pill once it's
+	// followed by a space and spells out a complete, known tag — e.g. typing "w " (or picking
+	// "w" from the suggestion row, which also appends a trailing space) moves "w" out of the
+	// free-text field entirely rather than leaving it there to be prefix/fuzzy-matched like
+	// prose. Recognizes multi-word tags too ("blue poison "), not just the single last word.
+	private func promoteTrailingTagIfNeeded() {
+		guard destination == .artwork, searchText.hasSuffix(" ") else { return }
+		guard
+			let (canonical, remaining) = WallpaperSearch.trailingKnownTag(
+				in: searchText, canonicalTagsByNormalizedForm: Self.canonicalTagsByNormalizedForm)
+		else { return }
+		searchText = remaining
+		if !committedTags.contains(canonical) {
+			committedTags.append(canonical)
+		}
+	}
+}

--- a/Sources/ArknightsClient/Features/Customization/Presets/UI/PresetGalleryView.swift
+++ b/Sources/ArknightsClient/Features/Customization/Presets/UI/PresetGalleryView.swift
@@ -8,12 +8,25 @@ struct PresetGalleryView: View {
 	let destination: PresetGalleryDestination
 	@Environment(\.dismiss) private var dismiss
 	@Environment(\.accessibilityReduceMotion) private var reduceMotion
-	@State private var searchText = ""
-	@State private var selectedCategory: WallpaperCategory?
-	@State private var avatars: [PresetAvatar] = []
-	@State private var wallpapers: [PresetWallpaper] = []
-	@State private var isLoading = true
-	@State private var applyingItemID: String?
+	@State var searchText = ""
+	// Committed exact-tag filters shown as removable pills in the search field — promoted
+	// either by picking a tag suggestion or by typing a complete tag name followed by a
+	// space. Kept separate from free-text `searchText` so an exact tag (e.g. the single-letter
+	// "w" operator) never gets diluted by the prefix/substring matching free text uses. See
+	// PresetGalleryView+Search.swift.
+	@State var committedTags: [String] = []
+	// Set to `searchText` right after a suggestion chip is picked, and compared against it in
+	// `searchSuggestions` to hide the row immediately — otherwise the just-picked word (now
+	// followed only by a trailing space) still looks like something worth suggesting itself.
+	// Typing anything further changes `searchText` away from this snapshot, which naturally
+	// restores normal suggestions.
+	@State var lastAppliedSuggestionText: String?
+	@FocusState var isSearchFieldFocused: Bool
+	@State var selectedCategory: WallpaperCategory?
+	@State var avatars: [PresetAvatar] = []
+	@State var wallpapers: [PresetWallpaper] = []
+	@State var isLoading = true
+	@State var applyingItemID: String?
 	@State private var showsIconStylePreview = false
 	private let avatarColumns = [
 		GridItem(.adaptive(minimum: 120, maximum: 140), spacing: 16)
@@ -37,13 +50,6 @@ struct PresetGalleryView: View {
 	var body: some View {
 		let hasSearchQuery = !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 		let filteredAvatars = PresetCatalogSearch.avatars(matching: searchText, in: avatars)
-		let filteredWallpapers = PresetCatalogSearch.wallpapers(
-			matching: searchText, category: selectedCategory, in: wallpapers)
-		let categoryWallpapers = wallpapers.filter {
-			selectedCategory == nil || $0.category == selectedCategory
-		}
-		let wallpaperTerms = PresetCatalogSearch.wallpaperSuggestions(
-			matching: searchText, in: categoryWallpapers)
 		ZStack(alignment: .bottomTrailing) {
 			VStack(spacing: 0) {
 				PresetGalleryHeader(
@@ -138,15 +144,6 @@ struct PresetGalleryView: View {
 			guard !Task.isCancelled, taskDestination == destination else { return }
 			isLoading = false
 		}
-	}
-	private var searchBar: some View {
-		ThemedTextField(
-			L10n.string(CustomizationStrings.searchLabel),
-			prompt: L10n.string(destination.searchPlaceholder),
-			text: $searchText,
-			systemImage: "magnifyingglass",
-			accentColor: customization.accentColor
-		)
 	}
 	private func avatarsGrid(_ filteredAvatars: [PresetAvatar]) -> some View {
 		LazyVGrid(columns: avatarColumns, spacing: 18) {

--- a/Sources/ArknightsClient/Resources/Customization.xcstrings
+++ b/Sources/ArknightsClient/Resources/Customization.xcstrings
@@ -235,6 +235,24 @@
         }
       }
     },
+    "customization.gallery.search.clear": {
+      "comment": "Accessibility label for the button that clears the gallery search field and any committed tag filters",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suche löschen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear search"
+          }
+        }
+      }
+    },
     "customization.gallery.search.label": {
       "comment": "Accessibility label for the current gallery search field",
       "extractionState": "manual",
@@ -249,6 +267,24 @@
           "stringUnit": {
             "state": "translated",
             "value": "Search gallery"
+          }
+        }
+      }
+    },
+    "customization.gallery.search.removeTag": {
+      "comment": "Accessibility label for the button that removes one committed tag filter pill from the gallery search field; tag name is supplied content",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tag „%1$@“ entfernen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove %1$@ tag"
           }
         }
       }

--- a/Tests/ArknightsClientTests/Customization/Presets/WallpaperSearchSuggestionsTests.swift
+++ b/Tests/ArknightsClientTests/Customization/Presets/WallpaperSearchSuggestionsTests.swift
@@ -40,4 +40,48 @@ struct WallpaperSearchSuggestionsTests {
 			WallpaperSearch.applyingSuggestion("angelina", to: "twitter ang")
 				== "twitter angelina ")
 	}
+
+	@Test("trailingKnownTag recognizes a multi-word tag as one unit, not its last word alone")
+	func trailingKnownTagRecognizesMultiWordTags() {
+		let canonicalTags = [WallpaperSearch.normalized("blue poison"): "blue poison"]
+		let result = WallpaperSearch.trailingKnownTag(
+			in: "blue poison ", canonicalTagsByNormalizedForm: canonicalTags)
+		#expect(result?.tag == "blue poison")
+		#expect(result?.remainingQuery == "")
+	}
+
+	@Test("trailingKnownTag keeps earlier free text when the trailing phrase is the tag")
+	func trailingKnownTagKeepsEarlierFreeText() {
+		let canonicalTags = [WallpaperSearch.normalized("blue poison"): "blue poison"]
+		let result = WallpaperSearch.trailingKnownTag(
+			in: "twitter blue poison ", canonicalTagsByNormalizedForm: canonicalTags)
+		#expect(result?.tag == "blue poison")
+		#expect(result?.remainingQuery == "twitter ")
+	}
+
+	@Test("trailingKnownTag still recognizes a single-word tag")
+	func trailingKnownTagRecognizesSingleWordTags() {
+		let canonicalTags = [WallpaperSearch.normalized("w"): "w"]
+		let result = WallpaperSearch.trailingKnownTag(
+			in: "twitter w ", canonicalTagsByNormalizedForm: canonicalTags)
+		#expect(result?.tag == "w")
+		#expect(result?.remainingQuery == "twitter ")
+	}
+
+	@Test("trailingKnownTag prefers the longest match over a shorter trailing word alone")
+	func trailingKnownTagPrefersLongestMatch() {
+		let canonicalTags = [WallpaperSearch.normalized("kristen wright"): "kristen wright"]
+		let result = WallpaperSearch.trailingKnownTag(
+			in: "kristen wright ", canonicalTagsByNormalizedForm: canonicalTags)
+		#expect(result?.tag == "kristen wright")
+		#expect(result?.remainingQuery == "")
+	}
+
+	@Test("trailingKnownTag returns nil when nothing trailing is a known tag")
+	func trailingKnownTagReturnsNilWhenNoMatch() {
+		#expect(
+			WallpaperSearch.trailingKnownTag(
+				in: "twitter random ", canonicalTagsByNormalizedForm: [:]
+			) == nil)
+	}
 }

--- a/Tests/ArknightsClientTests/Customization/Presets/WallpaperSearchTests.swift
+++ b/Tests/ArknightsClientTests/Customization/Presets/WallpaperSearchTests.swift
@@ -197,4 +197,14 @@ struct WallpaperSearchTests {
 			))
 	}
 
+	@Test("tagsContain requires an exact tag, not a prefix or substring")
+	func tagsContainRequiresExactMatch() {
+		#expect(WallpaperSearch.tagsContain(["w", "amiya"], exactly: "w"))
+		#expect(!WallpaperSearch.tagsContain(["warfarin"], exactly: "w"))
+	}
+
+	@Test("tagsContain folds diacritics the same way matches(...) does")
+	func tagsContainFoldsDiacritics() {
+		#expect(WallpaperSearch.tagsContain(["młynar"], exactly: "mlynar"))
+	}
 }


### PR DESCRIPTION
## Summary

`#61` ("feat: filter wallpapers by type, add tag/title autocomplete with pills") implemented and described committed-tag pills: typing a complete tag name (or picking one from autocomplete) promotes it out of free text into a removable pill shown in the search field, so an exact tag like the single-letter `w` operator is never diluted by prefix/substring matching against longer tags.

That implementation genuinely existed on the feature branch (`52ff6b4`, including `committedTags`, `PresetGalleryView+Search.swift`, `WallpaperSearch.trailingKnownTag`/`tagsContain`) — but it was silently dropped in `cb6b79b` ("Merge version-0.5.0 into wallpaper tag search"), which reconciled the feature branch against `version-0.5.0`'s own concurrent search-bar work. That merge kept `version-0.5.0`'s plain `ThemedTextField`-based search bar and only carried over the matching/suggestion logic, not the pill UI. `#61`'s own test plan left "autocomplete pills promote/remove correctly" unchecked, and the shipped v0.5.0 search field has never actually had this behavior — typing or picking a tag just inserts plain text, with no way to see or remove it as a distinct filter.

This restores it against the current gallery structure:
- `WallpaperSearch.swift`: adds back `trailingKnownTag(...)` and `tagsContain(...)`.
- `PresetGalleryView+Search.swift` (new): search bar with committed-tag pills, sized to a fixed content height so committing a tag never changes the bar's height, using `.onTapGesture` instead of `Button` for the clear/remove glyphs — a macOS `Button` wrapping only an `Image` hit-tests against the glyph's own rendered pixels rather than its full frame, so `.contentShape()` alone doesn't enlarge the click target.
- `PresetGalleryView.swift`: threads `committedTags` through the existing `WallpaperCategoryFilter`/`PresetGallerySuggestions` wiring so a wallpaper must carry every committed tag exactly before the free-text query and type filter apply.
- New `searchClear`/`searchRemoveTag(_:)` localization keys (English and German).

Both `PresetGalleryView.swift` (344 lines) and the new `PresetGalleryView+Search.swift` (163 lines) stay under the project's 350-line guideline for handwritten Swift.

## Test plan

- [x] `just check` — 338/338 Swift tests pass (adds back the 2 `tagsContain` tests and 5 `trailingKnownTag` tests from `52ff6b4`).
- [x] Built the real release app and manually verified: typing a complete tag followed by a space (e.g. `w `) promotes it into a pill; picking a tag from the suggestion row does the same; the pill's × and the field's clear × both work anywhere in their enlarged tap target, not just on the glyph itself; the search bar's height stays constant with or without pills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UyT5JbE6Vxh1QYaDwsxwh