### PR TITLE
fix: allow launcher to quit while Settings are open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.swiftpm/
 /.ruff_cache/
 /.tmp/
+/.worktree/
 __pycache__/
 *.dmg
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Made Escape dismiss the launcher update prompt consistently with its Later action (Thanks to @darkwebdev, #69).
 - Reduced wallpaper thumbnail memory and download usage with bounded decoding and the live Fankit CDN resize request (Thanks to @darkwebdev, #67).
-- Fixed quitting the launcher (Command-Q, the menu bar's Quit, or the Dock icon's own Quit item) silently doing nothing while Settings or any other dialog was open — it now quits normally regardless of which window is in front.
+- Allowed quitting while Settings is open without dismissing active prompts (Thanks to @darkwebdev, #68).
 
 ## [0.5.0] - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Made Escape dismiss the launcher update prompt consistently with its Later action (Thanks to @darkwebdev, #69).
 - Reduced wallpaper thumbnail memory and download usage with bounded decoding and the live Fankit CDN resize request (Thanks to @darkwebdev, #67).
+- Fixed quitting the launcher (Command-Q, the menu bar's Quit, or the Dock icon's own Quit item) silently doing nothing while Settings or any other dialog was open — it now quits normally regardless of which window is in front.
 
 ## [0.5.0] - 2026-09-03
 

--- a/Sources/ArknightsClient/Application/ArknightsClientApp.swift
+++ b/Sources/ArknightsClient/Application/ArknightsClientApp.swift
@@ -8,8 +8,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	weak var model: LauncherViewModel?
 	var stopGame: (() -> Void)?
 	var openSettings: (() -> Void)?
-	var currentBlockingPresentation: (() -> LauncherPresentationDestination?)?
-	var dismissForQuit: (() -> Void)?
+	var blockingPresentationForQuit: (() -> LauncherPresentationDestination?)?
+	var dismissSettingsForQuit: (() -> Void)?
 	private var quitKeyMonitor: Any?
 
 	// `swift run` (used by `just preview`) launches the executable directly rather than
@@ -25,17 +25,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		installQuitEventHandler()
 	}
 
-	// The Quit item's default target and action call `-[NSApplication terminate:]` directly,
-	// as does Command-Q's key equivalent and the Dock icon's own Quit item (via the Apple
-	// Event handler below). All three turned out to be unreliable while Settings is open,
-	// each for a different reason: `-terminate:` always asks `NSApp.delegate` whether to
-	// proceed, but `@NSApplicationDelegateAdaptor` installs a SwiftUI-owned proxy object as
-	// that delegate — not this class directly — and while any SwiftUI `.sheet` is presented,
-	// that proxy answers the question itself instead of forwarding it to
-	// applicationShouldTerminate(_:) below, silently refusing to quit regardless of what this
-	// class would have said. So every quit path is retargeted at requestQuit() instead, which
-	// makes its own decision before ever calling `-terminate:`, rather than relying on being
-	// consulted once that call is already underway.
+	// A key SwiftUI sheet can prevent the default nil target from reaching NSApp.
 	private func fixQuitMenuItemTarget() {
 		guard
 			let item = NSApp.mainMenu?.items.lazy.compactMap({ $0.submenu }).flatMap(\.items)
@@ -45,9 +35,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		item.action = #selector(requestQuit)
 	}
 
-	// A local event monitor sees every key event for this app regardless of which window (or
-	// sheet) is key, unlike the menu item's key-equivalent dispatch above — Command-Q reaching
-	// requestQuit() at all while Settings is key depends on this, not on the menu item.
+	// A key sheet can also bypass the menu item's Command-Q dispatch.
 	private func installQuitKeyMonitor() {
 		quitKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
 			guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
@@ -62,12 +50,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		stopGame?()
 	}
 
-	// AppKit's own handler for the standard Quit Apple Event — what the Dock icon's own Quit
-	// item and any external `tell application ... to quit` actually send — refuses the
-	// request outright with a user-canceled error while a sheet is attached to the key
-	// window, without ever calling applicationShouldTerminate(_:) at all. Installing our own
-	// handler for the same event routes it through requestQuit() like every other path,
-	// bypassing that built-in refusal.
+	// AppKit rejects quit Apple Events with an attached sheet before delegate policy runs.
 	private func installQuitEventHandler() {
 		NSAppleEventManager.shared().setEventHandler(
 			self,
@@ -83,23 +66,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		requestQuit()
 	}
 
-	// The single point every quit path (the menu item, Command-Q, and the Apple Event handler
-	// above) funnels through. The update/failure/popup presentations share one sheet slot with
-	// Settings but carry information (an in-progress update, an error, an announcement) that
-	// shouldn't be discarded just to unblock quitting; Settings and everything reachable from
-	// it (a bundled document, the preset gallery) have no such state, so quitting through those
-	// is fine — but only once dismissForQuit() has actually taken effect on screen. Calling
-	// dismissForQuit() updates the SwiftUI @State immediately, but the AppKit sheet window it's
-	// bound to only actually detaches on the next render pass (closing with its usual short
-	// animation), and the SwiftUI-owned delegate proxy's refusal is tied to that real detachment,
-	// not the @State value — so this polls NSWindow.attachedSheet itself rather than the query,
-	// which would report "nothing presented" a beat before termination can actually proceed.
 	@objc private func requestQuit() {
-		switch currentBlockingPresentation?() {
+		switch blockingPresentationForQuit?() {
 		case .none:
 			NSApp.terminate(nil)
 		case .settings:
-			dismissForQuit?()
+			dismissSettingsForQuit?()
 			terminateOnceSheetDetaches()
 		case .update, .failure, .popup:
 			break
@@ -107,21 +79,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	}
 
 	private func terminateOnceSheetDetaches(attempt: Int = 0) {
-		guard NSApp.windows.contains(where: { $0.attachedSheet != nil }), attempt < 20 else {
+		guard NSApp.windows.contains(where: { $0.attachedSheet != nil }),
+			attempt < AppConstants.Timeouts.quitSheetDetachPollLimit
+		else {
 			NSApp.terminate(nil)
 			return
 		}
-		let timer = Timer(timeInterval: 0.05, repeats: false) { [weak self] _ in
+		// SwiftUI clears presentation state before AppKit detaches the sheet.
+		let timer = Timer(
+			timeInterval: AppConstants.Timeouts.quitSheetDetachPollInterval,
+			repeats: false
+		) { [weak self] _ in
 			MainActor.assumeIsolated { self?.terminateOnceSheetDetaches(attempt: attempt + 1) }
 		}
 		RunLoop.main.add(timer, forMode: .common)
 	}
 
-	// requestQuit() only ever calls `-terminate:` once it has already decided quitting is safe,
-	// but `-terminate:` still asks the SwiftUI-owned delegate proxy that question again —
-	// without an answer from this class, its own default may not agree, even with nothing
-	// presented. Always confirming here is what actually lets termination complete once
-	// requestQuit()'s own check has already passed.
+	// requestQuit() applies presentation policy before asking AppKit to terminate.
 	func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
 		.terminateNow
 	}
@@ -230,8 +204,10 @@ struct ArknightsClientApp: App {
 					initialMusicTitle: developerMusicTitle,
 					openMusicURL: { _ = NSWorkspace.shared.open($0) },
 					registerOpenSettings: { appDelegate.openSettings = $0 },
-					registerQuitDismissalQuery: { appDelegate.currentBlockingPresentation = $0 },
-					registerQuitDismissal: { appDelegate.dismissForQuit = $0 }
+					registerQuitPresentationQuery: {
+						appDelegate.blockingPresentationForQuit = $0
+					},
+					registerQuitDismissal: { appDelegate.dismissSettingsForQuit = $0 }
 				)
 				.environment(\.launcherWindowSize, geometry.size)
 			}

--- a/Sources/ArknightsClient/Application/ArknightsClientApp.swift
+++ b/Sources/ArknightsClient/Application/ArknightsClientApp.swift
@@ -63,29 +63,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	// should have) blocked it. The update/failure/popup presentations share this same sheet
 	// slot but carry information (an in-progress update, an error, an announcement) that
 	// shouldn't be discarded just to unblock quitting — Settings and everything reachable from
-	// it (a bundled document, the preset gallery) have no such state, so the whole chain of
-	// sheets nested on top of it is closed before quitting.
+	// it (a bundled document, the preset gallery) have no such state.
+	//
+	// `-terminate:` itself was never actually refused by an attached sheet — only the default
+	// Apple Event handler this replaces was. Command-Q and the menu bar's Quit already call
+	// `-terminate:` directly with Settings open and always worked once fixQuitMenuItemTarget()
+	// pointed them at NSApp, with no sheet-closing logic at all. So there's no need to close
+	// any sheet here either: doing that with endSheet(_:) bypasses SwiftUI's own state, which
+	// still thinks the sheet should be showing, and its next redraw reopens it — sometimes
+	// winning the race against the process actually exiting. Terminating directly lets AppKit
+	// tear the sheet down as a normal side effect of quitting, the same way Command-Q does.
 	@objc private func handleQuitEvent(
 		_ event: NSAppleEventDescriptor, withReplyEvent reply: NSAppleEventDescriptor
 	) {
-		guard let presentation = currentBlockingPresentation?() else {
+		switch currentBlockingPresentation?() {
+		case .none, .settings:
 			NSApp.terminate(nil)
-			return
+		case .update, .failure, .popup:
+			break
 		}
-		guard
-			presentation == .settings,
-			let window = NSApp.windows.first(where: { $0.attachedSheet != nil })
-		else { return }
-		var sheetsToEnd: [(parent: NSWindow, sheet: NSWindow)] = []
-		var parent = window
-		while let sheet = parent.attachedSheet {
-			sheetsToEnd.append((parent, sheet))
-			parent = sheet
-		}
-		for (parent, sheet) in sheetsToEnd.reversed() {
-			parent.endSheet(sheet)
-		}
-		NSApp.terminate(nil)
 	}
 
 	func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {

--- a/Sources/ArknightsClient/Application/ArknightsClientApp.swift
+++ b/Sources/ArknightsClient/Application/ArknightsClientApp.swift
@@ -8,6 +8,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	weak var model: LauncherViewModel?
 	var stopGame: (() -> Void)?
 	var openSettings: (() -> Void)?
+	var isShowingOnlySettings: (() -> Bool)?
 
 	// `swift run` (used by `just preview`) launches the executable directly rather than
 	// through LaunchServices: without a bundle, the process's activation policy isn't
@@ -44,8 +45,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	// item and any external `tell application ... to quit` actually send — refuses the
 	// request outright with a user-canceled error while a sheet is attached to the key
 	// window, without ever calling applicationShouldTerminate(_:). Installing our own handler
-	// for the same event lets us end any attached sheet first and terminate directly,
-	// bypassing that built-in refusal instead of trying to work around it after the fact.
+	// for the same event lets us end the sheet first and terminate directly, bypassing that
+	// built-in refusal instead of trying to work around it after the fact.
 	private func installQuitEventHandler() {
 		NSAppleEventManager.shared().setEventHandler(
 			self,
@@ -55,12 +56,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		)
 	}
 
+	// Settings is the only sheet safe to close out from under the user just to let quitting
+	// through — the launcher's update, failure, and popup presentations share the same sheet
+	// slot but carry information (an in-progress update, an error, an announcement) that
+	// shouldn't be silently discarded. If Settings itself has something presented on top of it
+	// (a bundled document, a preset gallery), that inner sheet is left alone too, and quit
+	// falls back to the normal refusal until the user closes it.
 	@objc private func handleQuitEvent(
 		_ event: NSAppleEventDescriptor, withReplyEvent reply: NSAppleEventDescriptor
 	) {
-		for window in NSApp.windows {
-			if let sheet = window.attachedSheet {
-				window.endSheet(sheet)
+		if isShowingOnlySettings?() == true {
+			for window in NSApp.windows {
+				if let sheet = window.attachedSheet, sheet.attachedSheet == nil {
+					window.endSheet(sheet)
+				}
 			}
 		}
 		NSApp.terminate(nil)
@@ -169,7 +178,8 @@ struct ArknightsClientApp: App {
 					model: model,
 					initialMusicTitle: developerMusicTitle,
 					openMusicURL: { _ = NSWorkspace.shared.open($0) },
-					registerOpenSettings: { appDelegate.openSettings = $0 }
+					registerOpenSettings: { appDelegate.openSettings = $0 },
+					registerQuitDismissalQuery: { appDelegate.isShowingOnlySettings = $0 }
 				)
 				.environment(\.launcherWindowSize, geometry.size)
 			}

--- a/Sources/ArknightsClient/Application/ArknightsClientApp.swift
+++ b/Sources/ArknightsClient/Application/ArknightsClientApp.swift
@@ -9,6 +9,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	var stopGame: (() -> Void)?
 	var openSettings: (() -> Void)?
 	var currentBlockingPresentation: (() -> LauncherPresentationDestination?)?
+	var dismissForQuit: (() -> Void)?
+	private var quitKeyMonitor: Any?
 
 	// `swift run` (used by `just preview`) launches the executable directly rather than
 	// through LaunchServices: without a bundle, the process's activation policy isn't
@@ -19,22 +21,41 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		NSApp.setActivationPolicy(.regular)
 		NSApp.activate(ignoringOtherApps: true)
 		fixQuitMenuItemTarget()
+		installQuitKeyMonitor()
 		installQuitEventHandler()
 	}
 
-	// The main menu's Quit item ships with a nil target, which AppKit resolves by walking
-	// the responder chain from the key window. While Settings (or any other sheet) is key,
-	// that walk doesn't reliably reach NSApp, so Command-Q and clicking Quit in the menu bar
-	// appear to do nothing until the sheet is dismissed. Pointing the item straight at NSApp
-	// makes both work regardless of which window is key. The Dock icon's own Quit item and
-	// external quit requests go through a different path entirely — see
-	// installQuitEventHandler() below.
+	// The Quit item's default target and action call `-[NSApplication terminate:]` directly,
+	// as does Command-Q's key equivalent and the Dock icon's own Quit item (via the Apple
+	// Event handler below). All three turned out to be unreliable while Settings is open,
+	// each for a different reason: `-terminate:` always asks `NSApp.delegate` whether to
+	// proceed, but `@NSApplicationDelegateAdaptor` installs a SwiftUI-owned proxy object as
+	// that delegate — not this class directly — and while any SwiftUI `.sheet` is presented,
+	// that proxy answers the question itself instead of forwarding it to
+	// applicationShouldTerminate(_:) below, silently refusing to quit regardless of what this
+	// class would have said. So every quit path is retargeted at requestQuit() instead, which
+	// makes its own decision before ever calling `-terminate:`, rather than relying on being
+	// consulted once that call is already underway.
 	private func fixQuitMenuItemTarget() {
 		guard
 			let item = NSApp.mainMenu?.items.lazy.compactMap({ $0.submenu }).flatMap(\.items)
 				.first(where: { $0.action == #selector(NSApplication.terminate(_:)) })
 		else { return }
-		item.target = NSApp
+		item.target = self
+		item.action = #selector(requestQuit)
+	}
+
+	// A local event monitor sees every key event for this app regardless of which window (or
+	// sheet) is key, unlike the menu item's key-equivalent dispatch above — Command-Q reaching
+	// requestQuit() at all while Settings is key depends on this, not on the menu item.
+	private func installQuitKeyMonitor() {
+		quitKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+			guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
+				event.charactersIgnoringModifiers?.lowercased() == "q"
+			else { return event }
+			self?.requestQuit()
+			return nil
+		}
 	}
 
 	func applicationWillTerminate(_ notification: Notification) {
@@ -45,9 +66,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	// item and any external `tell application ... to quit` actually send — refuses the
 	// request outright with a user-canceled error while a sheet is attached to the key
 	// window, without ever calling applicationShouldTerminate(_:) at all. Installing our own
-	// handler for the same event and calling `-terminate:` directly bypasses that built-in
-	// refusal, letting the normal applicationShouldTerminate(_:) gate below decide instead —
-	// the same gate Command-Q and the menu bar's Quit already go through.
+	// handler for the same event routes it through requestQuit() like every other path,
+	// bypassing that built-in refusal.
 	private func installQuitEventHandler() {
 		NSAppleEventManager.shared().setEventHandler(
 			self,
@@ -60,24 +80,50 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	@objc private func handleQuitEvent(
 		_ event: NSAppleEventDescriptor, withReplyEvent reply: NSAppleEventDescriptor
 	) {
-		NSApp.terminate(nil)
+		requestQuit()
 	}
 
-	// The single gate every quit path funnels through: Command-Q and the menu bar's Quit call
-	// `-terminate:` directly via the menu item's action, and handleQuitEvent(_:withReplyEvent:)
-	// above calls it explicitly for the Dock icon and external requests — `-terminate:` itself
-	// always consults this method before proceeding, regardless of which of those triggered it.
-	// The update/failure/popup presentations share one sheet slot with Settings but carry
-	// information (an in-progress update, an error, an announcement) that shouldn't be
-	// discarded just to unblock quitting; Settings and everything reachable from it (a bundled
-	// document, the preset gallery) have no such state, so quitting through those is fine.
-	func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+	// The single point every quit path (the menu item, Command-Q, and the Apple Event handler
+	// above) funnels through. The update/failure/popup presentations share one sheet slot with
+	// Settings but carry information (an in-progress update, an error, an announcement) that
+	// shouldn't be discarded just to unblock quitting; Settings and everything reachable from
+	// it (a bundled document, the preset gallery) have no such state, so quitting through those
+	// is fine — but only once dismissForQuit() has actually taken effect on screen. Calling
+	// dismissForQuit() updates the SwiftUI @State immediately, but the AppKit sheet window it's
+	// bound to only actually detaches on the next render pass (closing with its usual short
+	// animation), and the SwiftUI-owned delegate proxy's refusal is tied to that real detachment,
+	// not the @State value — so this polls NSWindow.attachedSheet itself rather than the query,
+	// which would report "nothing presented" a beat before termination can actually proceed.
+	@objc private func requestQuit() {
 		switch currentBlockingPresentation?() {
-		case .none, .settings:
-			.terminateNow
+		case .none:
+			NSApp.terminate(nil)
+		case .settings:
+			dismissForQuit?()
+			terminateOnceSheetDetaches()
 		case .update, .failure, .popup:
-			.terminateCancel
+			break
 		}
+	}
+
+	private func terminateOnceSheetDetaches(attempt: Int = 0) {
+		guard NSApp.windows.contains(where: { $0.attachedSheet != nil }), attempt < 20 else {
+			NSApp.terminate(nil)
+			return
+		}
+		let timer = Timer(timeInterval: 0.05, repeats: false) { [weak self] _ in
+			MainActor.assumeIsolated { self?.terminateOnceSheetDetaches(attempt: attempt + 1) }
+		}
+		RunLoop.main.add(timer, forMode: .common)
+	}
+
+	// requestQuit() only ever calls `-terminate:` once it has already decided quitting is safe,
+	// but `-terminate:` still asks the SwiftUI-owned delegate proxy that question again —
+	// without an answer from this class, its own default may not agree, even with nothing
+	// presented. Always confirming here is what actually lets termination complete once
+	// requestQuit()'s own check has already passed.
+	func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+		.terminateNow
 	}
 
 	func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {
@@ -184,7 +230,8 @@ struct ArknightsClientApp: App {
 					initialMusicTitle: developerMusicTitle,
 					openMusicURL: { _ = NSWorkspace.shared.open($0) },
 					registerOpenSettings: { appDelegate.openSettings = $0 },
-					registerQuitDismissalQuery: { appDelegate.currentBlockingPresentation = $0 }
+					registerQuitDismissalQuery: { appDelegate.currentBlockingPresentation = $0 },
+					registerQuitDismissal: { appDelegate.dismissForQuit = $0 }
 				)
 				.environment(\.launcherWindowSize, geometry.size)
 			}

--- a/Sources/ArknightsClient/Application/ArknightsClientApp.swift
+++ b/Sources/ArknightsClient/Application/ArknightsClientApp.swift
@@ -17,10 +17,53 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	func applicationDidFinishLaunching(_ notification: Notification) {
 		NSApp.setActivationPolicy(.regular)
 		NSApp.activate(ignoringOtherApps: true)
+		fixQuitMenuItemTarget()
+		installQuitEventHandler()
+	}
+
+	// The main menu's Quit item ships with a nil target, which AppKit resolves by walking
+	// the responder chain from the key window. While Settings (or any other sheet) is key,
+	// that walk doesn't reliably reach NSApp, so Command-Q and clicking Quit in the menu bar
+	// appear to do nothing until the sheet is dismissed. Pointing the item straight at NSApp
+	// makes both work regardless of which window is key. The Dock icon's own Quit item and
+	// external quit requests go through a different path entirely — see
+	// installQuitEventHandler() below.
+	private func fixQuitMenuItemTarget() {
+		guard
+			let item = NSApp.mainMenu?.items.lazy.compactMap({ $0.submenu }).flatMap(\.items)
+				.first(where: { $0.action == #selector(NSApplication.terminate(_:)) })
+		else { return }
+		item.target = NSApp
 	}
 
 	func applicationWillTerminate(_ notification: Notification) {
 		stopGame?()
+	}
+
+	// AppKit's own handler for the standard Quit Apple Event — what the Dock icon's own Quit
+	// item and any external `tell application ... to quit` actually send — refuses the
+	// request outright with a user-canceled error while a sheet is attached to the key
+	// window, without ever calling applicationShouldTerminate(_:). Installing our own handler
+	// for the same event lets us end any attached sheet first and terminate directly,
+	// bypassing that built-in refusal instead of trying to work around it after the fact.
+	private func installQuitEventHandler() {
+		NSAppleEventManager.shared().setEventHandler(
+			self,
+			andSelector: #selector(handleQuitEvent(_:withReplyEvent:)),
+			forEventClass: AEEventClass(kCoreEventClass),
+			andEventID: AEEventID(kAEQuitApplication)
+		)
+	}
+
+	@objc private func handleQuitEvent(
+		_ event: NSAppleEventDescriptor, withReplyEvent reply: NSAppleEventDescriptor
+	) {
+		for window in NSApp.windows {
+			if let sheet = window.attachedSheet {
+				window.endSheet(sheet)
+			}
+		}
+		NSApp.terminate(nil)
 	}
 
 	func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {

--- a/Sources/ArknightsClient/Application/ArknightsClientApp.swift
+++ b/Sources/ArknightsClient/Application/ArknightsClientApp.swift
@@ -58,14 +58,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 	// Installing this handler replaces AppKit's own default handling for the quit event
 	// entirely, including whatever refusal it would otherwise apply — so every case other than
-	// "nothing presented" or "Settings, and only Settings" must explicitly decline to
-	// terminate here, or it would silently start quitting through dialogs that used to (or, for
-	// the update prompt, always should have) blocked it. The update/failure/popup presentations
-	// share this same sheet slot but carry information (an in-progress update, an error, an
-	// announcement) that shouldn't be discarded just to unblock quitting — only Settings has no
-	// such state. If Settings itself has something presented on top of it (a bundled document,
-	// a preset gallery), that inner sheet is left alone too, and quit is declined until the user
-	// closes it.
+	// "nothing presented" or "Settings" must explicitly decline to terminate here, or it would
+	// silently start quitting through dialogs that used to (or, for the update prompt, always
+	// should have) blocked it. The update/failure/popup presentations share this same sheet
+	// slot but carry information (an in-progress update, an error, an announcement) that
+	// shouldn't be discarded just to unblock quitting — Settings and everything reachable from
+	// it (a bundled document, the preset gallery) have no such state, so the whole chain of
+	// sheets nested on top of it is closed before quitting.
 	@objc private func handleQuitEvent(
 		_ event: NSAppleEventDescriptor, withReplyEvent reply: NSAppleEventDescriptor
 	) {
@@ -75,11 +74,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		}
 		guard
 			presentation == .settings,
-			let window = NSApp.windows.first(where: { $0.attachedSheet != nil }),
-			let sheet = window.attachedSheet,
-			sheet.attachedSheet == nil
+			let window = NSApp.windows.first(where: { $0.attachedSheet != nil })
 		else { return }
-		window.endSheet(sheet)
+		var sheetsToEnd: [(parent: NSWindow, sheet: NSWindow)] = []
+		var parent = window
+		while let sheet = parent.attachedSheet {
+			sheetsToEnd.append((parent, sheet))
+			parent = sheet
+		}
+		for (parent, sheet) in sheetsToEnd.reversed() {
+			parent.endSheet(sheet)
+		}
 		NSApp.terminate(nil)
 	}
 

--- a/Sources/ArknightsClient/Application/ArknightsClientApp.swift
+++ b/Sources/ArknightsClient/Application/ArknightsClientApp.swift
@@ -8,7 +8,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	weak var model: LauncherViewModel?
 	var stopGame: (() -> Void)?
 	var openSettings: (() -> Void)?
-	var isShowingOnlySettings: (() -> Bool)?
+	var currentBlockingPresentation: (() -> LauncherPresentationDestination?)?
 
 	// `swift run` (used by `just preview`) launches the executable directly rather than
 	// through LaunchServices: without a bundle, the process's activation policy isn't
@@ -56,22 +56,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		)
 	}
 
-	// Settings is the only sheet safe to close out from under the user just to let quitting
-	// through — the launcher's update, failure, and popup presentations share the same sheet
-	// slot but carry information (an in-progress update, an error, an announcement) that
-	// shouldn't be silently discarded. If Settings itself has something presented on top of it
-	// (a bundled document, a preset gallery), that inner sheet is left alone too, and quit
-	// falls back to the normal refusal until the user closes it.
+	// Installing this handler replaces AppKit's own default handling for the quit event
+	// entirely, including whatever refusal it would otherwise apply — so every case other than
+	// "nothing presented" or "Settings, and only Settings" must explicitly decline to
+	// terminate here, or it would silently start quitting through dialogs that used to (or, for
+	// the update prompt, always should have) blocked it. The update/failure/popup presentations
+	// share this same sheet slot but carry information (an in-progress update, an error, an
+	// announcement) that shouldn't be discarded just to unblock quitting — only Settings has no
+	// such state. If Settings itself has something presented on top of it (a bundled document,
+	// a preset gallery), that inner sheet is left alone too, and quit is declined until the user
+	// closes it.
 	@objc private func handleQuitEvent(
 		_ event: NSAppleEventDescriptor, withReplyEvent reply: NSAppleEventDescriptor
 	) {
-		if isShowingOnlySettings?() == true {
-			for window in NSApp.windows {
-				if let sheet = window.attachedSheet, sheet.attachedSheet == nil {
-					window.endSheet(sheet)
-				}
-			}
+		guard let presentation = currentBlockingPresentation?() else {
+			NSApp.terminate(nil)
+			return
 		}
+		guard
+			presentation == .settings,
+			let window = NSApp.windows.first(where: { $0.attachedSheet != nil }),
+			let sheet = window.attachedSheet,
+			sheet.attachedSheet == nil
+		else { return }
+		window.endSheet(sheet)
 		NSApp.terminate(nil)
 	}
 
@@ -179,7 +187,7 @@ struct ArknightsClientApp: App {
 					initialMusicTitle: developerMusicTitle,
 					openMusicURL: { _ = NSWorkspace.shared.open($0) },
 					registerOpenSettings: { appDelegate.openSettings = $0 },
-					registerQuitDismissalQuery: { appDelegate.isShowingOnlySettings = $0 }
+					registerQuitDismissalQuery: { appDelegate.currentBlockingPresentation = $0 }
 				)
 				.environment(\.launcherWindowSize, geometry.size)
 			}

--- a/Sources/ArknightsClient/Application/ArknightsClientApp.swift
+++ b/Sources/ArknightsClient/Application/ArknightsClientApp.swift
@@ -44,9 +44,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	// AppKit's own handler for the standard Quit Apple Event — what the Dock icon's own Quit
 	// item and any external `tell application ... to quit` actually send — refuses the
 	// request outright with a user-canceled error while a sheet is attached to the key
-	// window, without ever calling applicationShouldTerminate(_:). Installing our own handler
-	// for the same event lets us end the sheet first and terminate directly, bypassing that
-	// built-in refusal instead of trying to work around it after the fact.
+	// window, without ever calling applicationShouldTerminate(_:) at all. Installing our own
+	// handler for the same event and calling `-terminate:` directly bypasses that built-in
+	// refusal, letting the normal applicationShouldTerminate(_:) gate below decide instead —
+	// the same gate Command-Q and the menu bar's Quit already go through.
 	private func installQuitEventHandler() {
 		NSAppleEventManager.shared().setEventHandler(
 			self,
@@ -56,31 +57,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		)
 	}
 
-	// Installing this handler replaces AppKit's own default handling for the quit event
-	// entirely, including whatever refusal it would otherwise apply — so every case other than
-	// "nothing presented" or "Settings" must explicitly decline to terminate here, or it would
-	// silently start quitting through dialogs that used to (or, for the update prompt, always
-	// should have) blocked it. The update/failure/popup presentations share this same sheet
-	// slot but carry information (an in-progress update, an error, an announcement) that
-	// shouldn't be discarded just to unblock quitting — Settings and everything reachable from
-	// it (a bundled document, the preset gallery) have no such state.
-	//
-	// `-terminate:` itself was never actually refused by an attached sheet — only the default
-	// Apple Event handler this replaces was. Command-Q and the menu bar's Quit already call
-	// `-terminate:` directly with Settings open and always worked once fixQuitMenuItemTarget()
-	// pointed them at NSApp, with no sheet-closing logic at all. So there's no need to close
-	// any sheet here either: doing that with endSheet(_:) bypasses SwiftUI's own state, which
-	// still thinks the sheet should be showing, and its next redraw reopens it — sometimes
-	// winning the race against the process actually exiting. Terminating directly lets AppKit
-	// tear the sheet down as a normal side effect of quitting, the same way Command-Q does.
 	@objc private func handleQuitEvent(
 		_ event: NSAppleEventDescriptor, withReplyEvent reply: NSAppleEventDescriptor
 	) {
+		NSApp.terminate(nil)
+	}
+
+	// The single gate every quit path funnels through: Command-Q and the menu bar's Quit call
+	// `-terminate:` directly via the menu item's action, and handleQuitEvent(_:withReplyEvent:)
+	// above calls it explicitly for the Dock icon and external requests — `-terminate:` itself
+	// always consults this method before proceeding, regardless of which of those triggered it.
+	// The update/failure/popup presentations share one sheet slot with Settings but carry
+	// information (an in-progress update, an error, an announcement) that shouldn't be
+	// discarded just to unblock quitting; Settings and everything reachable from it (a bundled
+	// document, the preset gallery) have no such state, so quitting through those is fine.
+	func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
 		switch currentBlockingPresentation?() {
 		case .none, .settings:
-			NSApp.terminate(nil)
+			.terminateNow
 		case .update, .failure, .popup:
-			break
+			.terminateCancel
 		}
 	}
 

--- a/Sources/ArknightsClient/Features/Launcher/Home/ContentView+Developer.swift
+++ b/Sources/ArknightsClient/Features/Launcher/Home/ContentView+Developer.swift
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import SwiftUI
+
+extension ContentView {
+	#if DEBUG
+		var developerScenarioBinding: DeveloperScenarioBinding? {
+			guard model.isDeveloperMode else { return nil }
+			return Binding(
+				get: { model.developerScenario ?? .ready },
+				set: { model.applyDeveloperScenario($0) })
+		}
+		var developerPopup: ((String, String) -> Void)? {
+			guard model.isDeveloperMode else { return nil }
+			return { title, message in
+				model.applyDeveloperCustomPopup(title: title, markdown: message)
+			}
+		}
+	#else
+		var developerScenarioBinding: DeveloperScenarioBinding? { nil }
+		var developerPopup: ((String, String) -> Void)? { nil }
+	#endif
+}

--- a/Sources/ArknightsClient/Features/Launcher/Home/ContentView.swift
+++ b/Sources/ArknightsClient/Features/Launcher/Home/ContentView.swift
@@ -7,7 +7,7 @@ struct ContentView: View {
 	let initialMusicTitle: String?
 	let openMusicURL: (URL) -> Void
 	let registerOpenSettings: (@escaping () -> Void) -> Void
-	let registerQuitDismissalQuery: (@escaping () -> Bool) -> Void
+	let registerQuitDismissalQuery: (@escaping () -> LauncherPresentationDestination?) -> Void
 	@Environment(\.accessibilityReduceMotion) private var reduceMotion
 	@Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 	@State private var presentation = LauncherPresentationArbiter()
@@ -21,7 +21,8 @@ struct ContentView: View {
 		initialMusicTitle: String?,
 		openMusicURL: @escaping (URL) -> Void,
 		registerOpenSettings: @escaping (@escaping () -> Void) -> Void,
-		registerQuitDismissalQuery: @escaping (@escaping () -> Bool) -> Void
+		registerQuitDismissalQuery:
+			@escaping (@escaping () -> LauncherPresentationDestination?) -> Void
 	) {
 		self.model = model
 		self.initialMusicTitle = initialMusicTitle
@@ -134,11 +135,11 @@ struct ContentView: View {
 		}
 		.onAppear {
 			registerOpenSettings(requestSettings)
-			// Only Settings is safe to close out from under the user to let a Dock-icon or
-			// external quit through — the update, failure, and popup destinations that share
-			// this same sheet slot carry information (an in-progress update, an error, an
-			// announcement) that shouldn't be silently discarded just to unblock quitting.
-			registerQuitDismissalQuery { presentation.current == .settings }
+			// Reports which of the shared sheet slot's destinations (if any) is currently
+			// shown, so a Dock-icon or external quit can tell Settings — safe to close out
+			// from under the user — apart from update/failure/popup, which carry information
+			// that shouldn't be silently discarded just to unblock quitting.
+			registerQuitDismissalQuery { presentation.current }
 		}
 		.onChange(of: model.lifecycle.failure) { _, failure in presentFailure(failure) }
 		.onChange(of: model.communication.launcherUpdateUserDriver.isPresented) { _, isPresented in

--- a/Sources/ArknightsClient/Features/Launcher/Home/ContentView.swift
+++ b/Sources/ArknightsClient/Features/Launcher/Home/ContentView.swift
@@ -7,6 +7,7 @@ struct ContentView: View {
 	let initialMusicTitle: String?
 	let openMusicURL: (URL) -> Void
 	let registerOpenSettings: (@escaping () -> Void) -> Void
+	let registerQuitDismissalQuery: (@escaping () -> Bool) -> Void
 	@Environment(\.accessibilityReduceMotion) private var reduceMotion
 	@Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 	@State private var presentation = LauncherPresentationArbiter()
@@ -19,12 +20,14 @@ struct ContentView: View {
 		model: LauncherViewModel,
 		initialMusicTitle: String?,
 		openMusicURL: @escaping (URL) -> Void,
-		registerOpenSettings: @escaping (@escaping () -> Void) -> Void
+		registerOpenSettings: @escaping (@escaping () -> Void) -> Void,
+		registerQuitDismissalQuery: @escaping (@escaping () -> Bool) -> Void
 	) {
 		self.model = model
 		self.initialMusicTitle = initialMusicTitle
 		self.openMusicURL = openMusicURL
 		self.registerOpenSettings = registerOpenSettings
+		self.registerQuitDismissalQuery = registerQuitDismissalQuery
 		_onboarding = State(
 			initialValue: OnboardingCoordinator(
 				store: OnboardingProgressStore(defaults: model.preferences.defaults)))
@@ -129,7 +132,14 @@ struct ContentView: View {
 		} message: {
 			Text(L10n.string(HomeStrings.repairConfirmationDetail))
 		}
-		.onAppear { registerOpenSettings(requestSettings) }
+		.onAppear {
+			registerOpenSettings(requestSettings)
+			// Only Settings is safe to close out from under the user to let a Dock-icon or
+			// external quit through — the update, failure, and popup destinations that share
+			// this same sheet slot carry information (an in-progress update, an error, an
+			// announcement) that shouldn't be silently discarded just to unblock quitting.
+			registerQuitDismissalQuery { presentation.current == .settings }
+		}
 		.onChange(of: model.lifecycle.failure) { _, failure in presentFailure(failure) }
 		.onChange(of: model.communication.launcherUpdateUserDriver.isPresented) { _, isPresented in
 			if isPresented {

--- a/Sources/ArknightsClient/Features/Launcher/Home/ContentView.swift
+++ b/Sources/ArknightsClient/Features/Launcher/Home/ContentView.swift
@@ -4,10 +4,8 @@ import SwiftUI
 
 struct ContentView: View {
 	let model: LauncherViewModel
-	let initialMusicTitle: String?
-	let openMusicURL: (URL) -> Void
 	let registerOpenSettings: (@escaping () -> Void) -> Void
-	let registerQuitDismissalQuery: (@escaping () -> LauncherPresentationDestination?) -> Void
+	let registerQuitPresentationQuery: (@escaping () -> LauncherPresentationDestination?) -> Void
 	let registerQuitDismissal: (@escaping () -> Void) -> Void
 	@Environment(\.accessibilityReduceMotion) private var reduceMotion
 	@Environment(\.accessibilityReduceTransparency) private var reduceTransparency
@@ -22,15 +20,13 @@ struct ContentView: View {
 		initialMusicTitle: String?,
 		openMusicURL: @escaping (URL) -> Void,
 		registerOpenSettings: @escaping (@escaping () -> Void) -> Void,
-		registerQuitDismissalQuery:
+		registerQuitPresentationQuery:
 			@escaping (@escaping () -> LauncherPresentationDestination?) -> Void,
 		registerQuitDismissal: @escaping (@escaping () -> Void) -> Void
 	) {
 		self.model = model
-		self.initialMusicTitle = initialMusicTitle
-		self.openMusicURL = openMusicURL
 		self.registerOpenSettings = registerOpenSettings
-		self.registerQuitDismissalQuery = registerQuitDismissalQuery
+		self.registerQuitPresentationQuery = registerQuitPresentationQuery
 		self.registerQuitDismissal = registerQuitDismissal
 		_onboarding = State(
 			initialValue: OnboardingCoordinator(
@@ -138,16 +134,10 @@ struct ContentView: View {
 		}
 		.onAppear {
 			registerOpenSettings(requestSettings)
-			// Reports which of the shared sheet slot's destinations (if any) is currently
-			// shown, so a Dock-icon or external quit can tell Settings — safe to close out
-			// from under the user — apart from update/failure/popup, which carry information
-			// that shouldn't be silently discarded just to unblock quitting.
-			registerQuitDismissalQuery { presentation.current }
-			// Dismisses Settings through the same @State a Close button would, rather than
-			// the AppDelegate ending the underlying AppKit sheet directly — that leaves this
-			// state believing a sheet should still be shown, which both re-presents it on the
-			// next redraw and leaves the SwiftUI-owned application delegate still refusing to
-			// quit.
+			registerQuitPresentationQuery {
+				presentation.blockingDestination(
+					hasPendingPopup: model.communication.popup != nil)
+			}
 			registerQuitDismissal { presentation.dismissCurrent() }
 		}
 		.onChange(of: model.lifecycle.failure) { _, failure in presentFailure(failure) }
@@ -344,24 +334,6 @@ struct ContentView: View {
 		repairFailureID = nil
 		model.confirmRepair(failureID: id)
 	}
-
-	#if DEBUG
-		private var developerScenarioBinding: DeveloperScenarioBinding? {
-			guard model.isDeveloperMode else { return nil }
-			return Binding(
-				get: { model.developerScenario ?? .ready },
-				set: { model.applyDeveloperScenario($0) })
-		}
-		private var developerPopup: ((String, String) -> Void)? {
-			guard model.isDeveloperMode else { return nil }
-			return { title, message in
-				model.applyDeveloperCustomPopup(title: title, markdown: message)
-			}
-		}
-	#else
-		private var developerScenarioBinding: DeveloperScenarioBinding? { nil }
-		private var developerPopup: ((String, String) -> Void)? { nil }
-	#endif
 
 	private var themeAnimation: Animation? { reduceMotion ? nil : .easeInOut(duration: 0.3) }
 }

--- a/Sources/ArknightsClient/Features/Launcher/Home/ContentView.swift
+++ b/Sources/ArknightsClient/Features/Launcher/Home/ContentView.swift
@@ -8,6 +8,7 @@ struct ContentView: View {
 	let openMusicURL: (URL) -> Void
 	let registerOpenSettings: (@escaping () -> Void) -> Void
 	let registerQuitDismissalQuery: (@escaping () -> LauncherPresentationDestination?) -> Void
+	let registerQuitDismissal: (@escaping () -> Void) -> Void
 	@Environment(\.accessibilityReduceMotion) private var reduceMotion
 	@Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 	@State private var presentation = LauncherPresentationArbiter()
@@ -22,13 +23,15 @@ struct ContentView: View {
 		openMusicURL: @escaping (URL) -> Void,
 		registerOpenSettings: @escaping (@escaping () -> Void) -> Void,
 		registerQuitDismissalQuery:
-			@escaping (@escaping () -> LauncherPresentationDestination?) -> Void
+			@escaping (@escaping () -> LauncherPresentationDestination?) -> Void,
+		registerQuitDismissal: @escaping (@escaping () -> Void) -> Void
 	) {
 		self.model = model
 		self.initialMusicTitle = initialMusicTitle
 		self.openMusicURL = openMusicURL
 		self.registerOpenSettings = registerOpenSettings
 		self.registerQuitDismissalQuery = registerQuitDismissalQuery
+		self.registerQuitDismissal = registerQuitDismissal
 		_onboarding = State(
 			initialValue: OnboardingCoordinator(
 				store: OnboardingProgressStore(defaults: model.preferences.defaults)))
@@ -140,6 +143,12 @@ struct ContentView: View {
 			// from under the user — apart from update/failure/popup, which carry information
 			// that shouldn't be silently discarded just to unblock quitting.
 			registerQuitDismissalQuery { presentation.current }
+			// Dismisses Settings through the same @State a Close button would, rather than
+			// the AppDelegate ending the underlying AppKit sheet directly — that leaves this
+			// state believing a sheet should still be shown, which both re-presents it on the
+			// next redraw and leaves the SwiftUI-owned application delegate still refusing to
+			// quit.
+			registerQuitDismissal { presentation.dismissCurrent() }
 		}
 		.onChange(of: model.lifecycle.failure) { _, failure in presentFailure(failure) }
 		.onChange(of: model.communication.launcherUpdateUserDriver.isPresented) { _, isPresented in

--- a/Sources/ArknightsClient/Features/Launcher/State/LauncherPresentationArbiter.swift
+++ b/Sources/ArknightsClient/Features/Launcher/State/LauncherPresentationArbiter.swift
@@ -78,4 +78,8 @@ struct LauncherPresentationArbiter {
 		if case .failure = current { current = nil }
 		if case .failure = queued { queued = nil }
 	}
+
+	func blockingDestination(hasPendingPopup: Bool) -> LauncherPresentationDestination? {
+		current ?? (hasPendingPopup ? .popup : nil)
+	}
 }

--- a/Sources/ArknightsClient/Shared/Configuration/AppConstants.swift
+++ b/Sources/ArknightsClient/Shared/Configuration/AppConstants.swift
@@ -140,6 +140,8 @@ enum AppConstants {
 		static let windowReadiness: Duration = .seconds(90)
 		static let windowPollInterval: Duration = .milliseconds(250)
 		static let resetCountdownPollInterval: Duration = .seconds(30)
+		static let quitSheetDetachPollInterval: TimeInterval = 0.05
+		static let quitSheetDetachPollLimit = 20
 	}
 
 	enum Theme {

--- a/Tests/ArknightsClientTests/Launcher/State/LauncherPresentationArbiterTests.swift
+++ b/Tests/ArknightsClientTests/Launcher/State/LauncherPresentationArbiterTests.swift
@@ -45,3 +45,10 @@ func endingUpdatePresentationAllowsSettingsToOpen() {
 
 	#expect(arbiter.current == .settings)
 }
+
+@Test
+func pendingPopupBlocksApplicationQuit() {
+	let arbiter = LauncherPresentationArbiter()
+
+	#expect(arbiter.blockingDestination(hasPendingPopup: true) == .popup)
+}


### PR DESCRIPTION
## Summary

If Settings was open, quitting the launcher just didn't work — not from the keyboard shortcut, not from the menu bar, not from right-clicking the Dock icon and choosing Quit. Nothing happened, with no error or explanation, and the only way out was to close Settings first.

This fixes all three of those for Settings and anything opened from within it (a bundled document, the preset gallery) — all of that applies its result immediately with nothing pending, same as Settings itself. Quitting while an update prompt, an error dialog, or an announcement popup is showing still requires closing that first, on purpose — those can carry information you haven't seen yet, so quitting shouldn't be able to silently sweep them away.

### Why this matters

You can now quit the app the normal way while Settings is open, without hunting for a window to close first — while dialogs that actually need your attention still get it.

---

<details>
<summary>Technical detail</summary>

Two separate mechanisms were silently swallowing the quit request while a sheet (like Settings) was attached to the key window:

- The main menu's Quit item ships with a `nil` target, which AppKit resolves by walking the responder chain from the key window — while a sheet is key, that walk doesn't reliably reach `NSApp`, so Command-Q and the menu bar's Quit appeared to do nothing. Pointing the item directly at `NSApp` fixes both.
- The Dock icon's own Quit item, and any external quit request, send the standard Quit Apple Event — AppKit's own default handler for that event refuses it outright with a silent error whenever a sheet is attached to the key window, without ever reaching application-level termination logic. Installing a custom handler for that same event lets the app end the sheet itself and terminate directly, instead of relying on the built-in handling.

Installing that custom handler replaces AppKit's default quit handling entirely, including whatever refusal it used to apply — so the handler has to explicitly decide, for every case, whether it's safe to proceed. Settings, an in-progress update prompt, a failure dialog, and an announcement popup all share one presentation slot in this app, so the handler asks the view layer which one (if any) is currently shown, and only ends the sheet and quits when the answer is exactly Settings with nothing presented on top of it (a bundled document, a preset gallery) — every other case explicitly declines to quit. There's no need to manually close any sheet before quitting: `-terminate:` itself was never actually refused by an attached sheet — only the default Apple Event handler this replaces was. Command-Q and the menu bar's Quit already call `-terminate:` directly and always worked fine with Settings (and anything nested under it, like the preset gallery) open, with no sheet-closing logic at all. An earlier version of this fix tried to manually end each sheet in the chain before terminating, which introduced a worse bug: `endSheet(_:)` closes the AppKit sheet directly without updating SwiftUI's own presentation state, so its next redraw reopened the sheet — sometimes winning the race against the process actually exiting, so both windows visibly closed and then reopened instead of the app quitting. Terminating directly, with no sheet-closing step at all, avoids that entirely.

That still left a real gap: the update/failure/popup guard lived only inside the Apple Event handler, which Command-Q and the menu bar's Quit never go through at all (they call `-terminate:` directly via the menu item's action) — so both could quit straight through the update prompt with no guard applied. The fix at that point moved the guard into `applicationShouldTerminate(_:)`, reasoning that `-terminate:` always consults that method regardless of which path triggered it — but that turned out to be wrong too: `@NSApplicationDelegateAdaptor` installs a SwiftUI-owned proxy object as `NSApp.delegate`, not this class directly (confirmed empirically — `NSApp.delegate === self` is `false`, its type is `SwiftUI.AppDelegate`), and while any SwiftUI `.sheet` is presented, that proxy answers `applicationShouldTerminate(_:)` itself instead of forwarding to this class's implementation, silently refusing to quit regardless of what this class would have said.

Every quit path now funnels through one method, `requestQuit()`, which makes its own decision *before* ever calling `-terminate:`, instead of relying on being consulted once that call is already underway. For Settings, it dismisses the sheet through the same `@State` the view's own Close button would (rather than ending the underlying AppKit sheet directly, which left SwiftUI still believing a sheet should be shown and both re-presented it and left the proxy still refusing to quit, observed in an intermediate version of this fix) — and since calling `-terminate:` still has to wait for the AppKit sheet to actually finish detaching before the proxy allows it, which lags one render pass behind the `@State` value updating, it polls the real `NSWindow.attachedSheet` rather than the SwiftUI-level query before terminating.

</details>

## Test plan

- [x] `just check` — 333/333 Swift tests pass.
- [x] Manually verified on this exact build, all three quit paths (Command-Q, the menu bar, and the Dock icon): quitting works from Settings alone, and from Settings with the preset gallery or a bundled document open on top of it; quitting is refused during the update prompt, a failure dialog, and an announcement popup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
