### PR TITLE
fix: Artwork gallery crashing on open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Made Escape dismiss the launcher update prompt consistently with its Later action (Thanks to @darkwebdev, #69).
 - Reduced wallpaper thumbnail memory and download usage with bounded decoding and the live Fankit CDN resize request (Thanks to @darkwebdev, #67).
 - Allowed quitting while Settings is open without dismissing active prompts (Thanks to @darkwebdev, #68).
-- Fixed the Artwork gallery crashing as soon as it loaded wallpaper tags.
+- Prevented Artwork gallery crashes in packaged builds by loading wallpaper tags from app resources (Thanks to @darkwebdev, #70).
 
 ## [0.5.0] - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Made Escape dismiss the launcher update prompt consistently with its Later action (Thanks to @darkwebdev, #69).
 - Reduced wallpaper thumbnail memory and download usage with bounded decoding and the live Fankit CDN resize request (Thanks to @darkwebdev, #67).
 - Allowed quitting while Settings is open without dismissing active prompts (Thanks to @darkwebdev, #68).
+- Fixed the Artwork gallery crashing as soon as it loaded wallpaper tags.
 
 ## [0.5.0] - 2026-09-03
 

--- a/Sources/ArknightsClient/Features/Customization/Presets/Models/PresetCatalogModels.swift
+++ b/Sources/ArknightsClient/Features/Customization/Presets/Models/PresetCatalogModels.swift
@@ -136,9 +136,7 @@ enum WallpaperTagCatalog {
 	}
 
 	private static func load() -> [String: [String]] {
-		// `WallpaperTags.json` is a `.copy()` package resource, so the packaged app copies it
-		// flat into `Contents/Resources` rather than into the SwiftPM `Bundle.module` bundle —
-		// the same pattern `AppIconRenderer+Avatars` uses for its own `.copy()` resources.
+		// Packaged apps flatten copied resources into Bundle.main; SwiftPM uses its resource bundle.
 		guard
 			let url = Bundle.main.url(forResource: "WallpaperTags", withExtension: "json")
 				?? AppResourceBundle.bundle.url(forResource: "WallpaperTags", withExtension: "json"),

--- a/Sources/ArknightsClient/Features/Customization/Presets/Models/PresetCatalogModels.swift
+++ b/Sources/ArknightsClient/Features/Customization/Presets/Models/PresetCatalogModels.swift
@@ -136,8 +136,12 @@ enum WallpaperTagCatalog {
 	}
 
 	private static func load() -> [String: [String]] {
+		// `WallpaperTags.json` is a `.copy()` package resource, so the packaged app copies it
+		// flat into `Contents/Resources` rather than into the SwiftPM `Bundle.module` bundle —
+		// the same pattern `AppIconRenderer+Avatars` uses for its own `.copy()` resources.
 		guard
-			let url = Bundle.module.url(forResource: "WallpaperTags", withExtension: "json"),
+			let url = Bundle.main.url(forResource: "WallpaperTags", withExtension: "json")
+				?? AppResourceBundle.bundle.url(forResource: "WallpaperTags", withExtension: "json"),
 			let data = try? Data(contentsOf: url),
 			let manifest = try? JSONDecoder().decode(WallpaperTagManifest.self, from: data),
 			manifest.schemaVersion == 1


### PR DESCRIPTION
## Summary

Opening the Artwork gallery crashed the app immediately — every time, for every user of the release build.

## Why this matters

Artwork was completely unusable in the real, shipped app. This fixes it: opening Artwork now works normally.

## How to reproduce

1. Install the official v0.5.0 DMG (or any build produced by `just dmg`/`just app` — not `swift run` or `just preview`, which resolve resources differently in a dev context).
2. Launch the app, open **Settings**, then under **Personalization → Artwork** click **Presets…**.
3. The app crashes immediately.

If you'd rather test a build you compiled yourself instead of a downloaded release: `Bundle.module` also has a second, build-machine-only fallback path baked in at compile time, which can coincidentally already exist if you've run `swift build`/`swift test` locally in the same checkout before packaging the app — that's exactly what masked the crash for me on the first attempt. To test reliably against your own local build, either delete `.build/arm64-apple-macosx/{debug,release}/ArknightsClient_ArknightsClient.bundle` first, or just test against the official downloaded DMG, which never has that fallback available.

---

<details>
<summary>Technical detail</summary>

`WallpaperTagCatalog.load()` looked up `WallpaperTags.json` via `Bundle.module`, the standard SwiftPM resource accessor. That resource is declared as a `.copy()` package resource, so the packaging script copies it flat into `Contents/Resources` instead of into the SwiftPM-generated `ArknightsClient_ArknightsClient.bundle` that `Bundle.module` actually looks for. In the real packaged `.app`, that generated bundle folder doesn't exist at all, so merely evaluating `Bundle.module` crashes with a `fatalError` — the instant the preset gallery renders a wallpaper's hover tooltip or computes search suggestions, i.e. the moment Artwork opens.

Fix: look up the resource the same way `AppIconRenderer+Avatars` already does for its own `.copy()` resources — try `Bundle.main` first (works in the packaged app, since that's exactly where the flat copy lands), falling back to `AppResourceBundle.bundle` (works under `swift run`/`swift test`, where `Bundle.main` isn't a real `.app`).

Reproduced for real, not just structurally: `Bundle.module` also has a build-machine-only fallback path baked in at compile time, and that path happened to exist on the dev machine used here (left over from earlier local test builds), which silently masked the crash on the first attempt. Hiding both the debug- and release-configuration fallback bundles to faithfully match a real end user's machine (which has neither) made the unfixed code crash immediately on opening Artwork, and confirmed the fix resolves it under those same conditions. Also confirmed directly against the actual official v0.5.0 DMG downloaded from GitHub Releases (not a local compile) — crashed immediately on opening Artwork, with no fix applied.

</details>

## Test plan

- [x] `just check` — 334/334 Swift tests pass.
- [x] Manually reproduced the crash on the official v0.5.0 DMG downloaded from GitHub Releases — confirmed it crashes immediately on opening Artwork.
- [x] Manually verified the fix resolves it: rebuilt with the fix applied, with both of `Bundle.module`'s fallback paths hidden (matching a real user's machine, which never has either) — Artwork now loads and scrolls normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)