### PR TITLE
feat: add wallpaper counts, an Operators filter, and richer hover info to Artwork gallery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added wallpaper counts to the Artwork gallery's category filter, plus an Operators submenu listing every operator featured in official wallpapers, sorted by how many they appear in.
+- Added the artist and curated tags to a wallpaper's hover tooltip in the Artwork gallery.
+
+### Changed
+
+- Limited Artwork gallery search suggestions to tag/word completions, no longer suggesting whole wallpaper titles as chips.
+
 ### Fixed
 
 - Made closing the launcher with the red traffic-light button terminate the app instead of leaving it suspended.

--- a/Sources/ArknightsClient/Features/Customization/CustomizationStrings.swift
+++ b/Sources/ArknightsClient/Features/Customization/CustomizationStrings.swift
@@ -75,4 +75,19 @@ enum CustomizationStrings {
 		case .holiday: .Customization.customizationGalleryWallpaperTypeHoliday
 		}
 	}
+
+	static func wallpaperFilterOption(_ title: String, count: Int) -> LocalizedStringResource {
+		.Customization.customizationGalleryWallpaperFilterOptionWithCount(title, count)
+	}
+
+	static let wallpaperFilterOperators = LocalizedStringResource.Customization
+		.customizationGalleryWallpaperFilterOperators
+
+	static func wallpaperHoverArtist(_ name: String) -> LocalizedStringResource {
+		.Customization.customizationGalleryWallpaperHoverArtist(name)
+	}
+
+	static func wallpaperHoverTags(_ tags: String) -> LocalizedStringResource {
+		.Customization.customizationGalleryWallpaperHoverTags(tags)
+	}
 }

--- a/Sources/ArknightsClient/Features/Customization/Presets/Models/PresetCatalogModels.swift
+++ b/Sources/ArknightsClient/Features/Customization/Presets/Models/PresetCatalogModels.swift
@@ -148,6 +148,14 @@ enum WallpaperTagCatalog {
 	}
 }
 
+/// An operator identified among a set of wallpapers, with how many of them feature them.
+struct OperatorArtCount: Identifiable, Hashable {
+	var id: String { tag }
+	let tag: String
+	let displayName: String
+	let count: Int
+}
+
 /// Decodes identity fields from `character_table.json`.
 struct RawCharacterEntry: Decodable {
 	let name: String

--- a/Sources/ArknightsClient/Features/Customization/Presets/UI/PresetGalleryGrids.swift
+++ b/Sources/ArknightsClient/Features/Customization/Presets/UI/PresetGalleryGrids.swift
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import SwiftUI
+
+/// The operator icon grid shown in the Operator gallery.
+struct PresetAvatarGrid: View {
+	let catalog: PresetCatalogService
+	let accentColor: Color
+	let avatars: [PresetAvatar]
+	let applyingItemID: String?
+	let onSelect: (PresetAvatar) -> Void
+
+	private let columns = [
+		GridItem(.adaptive(minimum: 120, maximum: 140), spacing: 16)
+	]
+
+	var body: some View {
+		LazyVGrid(columns: columns, spacing: 18) {
+			ForEach(avatars) { avatar in
+				let isApplying = applyingItemID == avatar.id
+				Button {
+					onSelect(avatar)
+				} label: {
+					VStack(spacing: 6) {
+						ZStack {
+							CachedPresetImage(
+								catalog: catalog,
+								url: avatar.url,
+								cacheKey: avatar.id,
+								contentMode: .fit,
+								placeholderIcon: "person.crop.square"
+							)
+							.frame(width: 104, height: 104)
+							.background(
+								LinearGradient(
+									colors: [
+										Color(red: 0.16, green: 0.17, blue: 0.19),
+										Color(red: 0.06, green: 0.06, blue: 0.07),
+									],
+									startPoint: .top,
+									endPoint: .bottom
+								)
+							)
+							.clipShape(RoundedRectangle(cornerRadius: 22))
+							if isApplying {
+								ZStack {
+									Color.black.opacity(0.65)
+									ProgressView()
+										.controlSize(.small)
+										.tint(accentColor)
+								}
+								.clipShape(RoundedRectangle(cornerRadius: 22))
+							}
+						}
+						.frame(width: 104, height: 104)
+						.overlay {
+							RoundedRectangle(cornerRadius: 22)
+								.strokeBorder(
+									isApplying ? accentColor : Color.white.opacity(0.14),
+									lineWidth: isApplying ? 2.5 : 1.5
+								)
+						}
+						.shadow(
+							color: isApplying ? accentColor.opacity(0.5) : Color.black.opacity(0.4),
+							radius: isApplying ? 8 : 5,
+							x: 0,
+							y: 3
+						)
+						Text(avatar.name)
+							.font(.caption.weight(isApplying ? .bold : .medium))
+							.lineLimit(2)
+							.truncationMode(.tail)
+							.foregroundStyle(isApplying ? accentColor : .primary)
+							.frame(maxWidth: 130)
+					}
+					.padding(.vertical, 4)
+					.frame(maxWidth: .infinity)
+					.contentShape(Rectangle())
+				}
+				.buttonStyle(.plain)
+				.keyboardFocusIndicator(in: RoundedRectangle(cornerRadius: 22))
+				.disabled(applyingItemID != nil)
+				.accessibilityLabel(avatar.name)
+				.accessibilityHint(
+					L10n.string(CustomizationStrings.operatorApplyHelp(avatar.name))
+				)
+				.accessibilityValue(
+					isApplying ? Text(L10n.string(CustomizationStrings.applying)) : Text("")
+				)
+			}
+		}
+	}
+}
+
+/// The official wallpaper grid shown in the Artwork gallery.
+struct PresetWallpaperGrid: View {
+	let catalog: PresetCatalogService
+	let accentColor: Color
+	let wallpapers: [PresetWallpaper]
+	let applyingItemID: String?
+	let onSelect: (PresetWallpaper) -> Void
+
+	private let columns = [
+		GridItem(.flexible(), spacing: 14),
+		GridItem(.flexible(), spacing: 14),
+		GridItem(.flexible(), spacing: 14),
+	]
+
+	var body: some View {
+		LazyVGrid(columns: columns, spacing: 14) {
+			ForEach(wallpapers) { wp in
+				let isApplying = applyingItemID == wp.id
+				Button {
+					onSelect(wp)
+				} label: {
+					VStack(alignment: .leading, spacing: 6) {
+						ZStack {
+							CachedPresetImage(
+								catalog: catalog,
+								url: wp.thumbnailURL ?? wp.url,
+								cacheKey: "thumb_\(wp.id)",
+								contentMode: .fill,
+								placeholderIcon: "photo"
+							)
+							.frame(minWidth: 0, maxWidth: .infinity)
+							.frame(height: 105)
+							.clipped()
+							.clipShape(RoundedRectangle(cornerRadius: 10))
+							if isApplying {
+								ZStack {
+									Color.black.opacity(0.68)
+									VStack(spacing: 6) {
+										ProgressView()
+											.controlSize(.regular)
+											.tint(accentColor)
+										Text(L10n.string(CustomizationStrings.applying))
+											.font(.caption2.bold())
+											.foregroundStyle(.white)
+									}
+								}
+								.clipShape(RoundedRectangle(cornerRadius: 10))
+							}
+						}
+						.frame(height: 105)
+						.background(Color.white.opacity(0.05), in: .rect(cornerRadius: 10))
+						Text(wp.displayTitle)
+							.font(.caption.weight(isApplying ? .bold : .medium))
+							.lineLimit(2)
+							.truncationMode(.tail)
+							.foregroundStyle(isApplying ? accentColor : .primary)
+					}
+					.padding(8)
+					.frame(maxWidth: .infinity)
+					.background(
+						isApplying ? accentColor.opacity(0.12) : Color.white.opacity(0.03),
+						in: .rect(cornerRadius: 12)
+					)
+					.overlay {
+						RoundedRectangle(cornerRadius: 12)
+							.strokeBorder(
+								isApplying ? accentColor : Color.white.opacity(0.07),
+								lineWidth: isApplying ? 2 : 1
+							)
+					}
+					.shadow(
+						color: isApplying ? accentColor.opacity(0.4) : .clear,
+						radius: 8,
+						x: 0,
+						y: 2
+					)
+				}
+				.buttonStyle(.plain)
+				.keyboardFocusIndicator(in: RoundedRectangle(cornerRadius: 12))
+				.disabled(applyingItemID != nil)
+				.accessibilityLabel(wp.displayTitle)
+				.accessibilityHint(
+					L10n.string(CustomizationStrings.wallpaperApplyHelp(wp.displayTitle))
+				)
+				.accessibilityValue(
+					isApplying ? Text(L10n.string(CustomizationStrings.applying)) : Text("")
+				)
+				.help(hoverText(for: wp))
+			}
+		}
+	}
+
+	private func hoverText(for wp: PresetWallpaper) -> String {
+		let tags = WallpaperTagCatalog.tags(for: wp.id).joined(separator: ", ")
+		return [
+			wp.author.map { L10n.string(CustomizationStrings.wallpaperHoverArtist($0)) },
+			tags.isEmpty ? nil : L10n.string(CustomizationStrings.wallpaperHoverTags(tags)),
+			wp.description,
+		]
+		.compactMap { $0 }
+		.joined(separator: "\n")
+	}
+}

--- a/Sources/ArknightsClient/Features/Customization/Presets/UI/PresetGallerySuggestions.swift
+++ b/Sources/ArknightsClient/Features/Customization/Presets/UI/PresetGallerySuggestions.swift
@@ -4,13 +4,11 @@ import SwiftUI
 
 private enum PresetGallerySuggestion: Identifiable {
 	case avatar(PresetAvatar)
-	case wallpaper(PresetWallpaper)
 	case wallpaperTerm(String)
 
 	var id: String {
 		switch self {
 		case .avatar(let avatar): "avatar_\(avatar.id)"
-		case .wallpaper(let wallpaper): "wallpaper_\(wallpaper.id)"
 		case .wallpaperTerm(let term): "wallpaper_term_\(term)"
 		}
 	}
@@ -18,41 +16,28 @@ private enum PresetGallerySuggestion: Identifiable {
 	var title: String {
 		switch self {
 		case .avatar(let avatar): avatar.name
-		case .wallpaper(let wallpaper): wallpaper.displayTitle
 		case .wallpaperTerm(let term): term
 		}
 	}
 
-	var subtitle: String? {
-		switch self {
-		case .avatar, .wallpaperTerm: return nil
-		case .wallpaper(let wallpaper): return wallpaper.author
-		}
-	}
+	var accessibilityTitle: String { title }
 
-	var accessibilityTitle: String {
-		[title, subtitle].compactMap { $0 }.joined(separator: ", ")
-	}
-
-	var compactTitle: String {
-		[title, subtitle].compactMap { $0 }.joined(separator: " · ")
-	}
+	var compactTitle: String { title }
 }
 
 struct PresetGallerySuggestions: View {
 	let destination: PresetGalleryDestination
 	let avatars: [PresetAvatar]
-	let wallpapers: [PresetWallpaper]
 	let wallpaperTerms: [String]
 	let onSelect: (String) -> Void
 	@Environment(\.accessibilityReduceMotion) private var reduceMotion
 
+	// Only ever offers tag/title-word completions for Artwork, never a whole matching
+	// wallpaper as a suggestion chip — the grid below already shows those results directly,
+	// so a chip here is worth showing only when it can actually complete what's being typed.
 	private var suggestions: [PresetGallerySuggestion] {
 		if destination == .artwork {
-			if !wallpaperTerms.isEmpty { return wallpaperTerms.map { .wallpaperTerm($0) } }
-			return wallpapers.prefix(AppConstants.Presets.gallerySuggestionLimit).map {
-				.wallpaper($0)
-			}
+			return wallpaperTerms.map { .wallpaperTerm($0) }
 		}
 		return avatars.prefix(AppConstants.Presets.gallerySuggestionLimit).map { .avatar($0) }
 	}

--- a/Sources/ArknightsClient/Features/Customization/Presets/UI/PresetGalleryView.swift
+++ b/Sources/ArknightsClient/Features/Customization/Presets/UI/PresetGalleryView.swift
@@ -16,14 +16,6 @@ struct PresetGalleryView: View {
 	@State private var isLoading = true
 	@State private var applyingItemID: String?
 	@State private var showsIconStylePreview = false
-	private let avatarColumns = [
-		GridItem(.adaptive(minimum: 120, maximum: 140), spacing: 16)
-	]
-	private let wallpaperColumns = [
-		GridItem(.flexible(), spacing: 14),
-		GridItem(.flexible(), spacing: 14),
-		GridItem(.flexible(), spacing: 14),
-	]
 	init(
 		catalog: PresetCatalogService,
 		customization: CustomizationController,
@@ -71,7 +63,12 @@ struct PresetGalleryView: View {
 					if destination == .artwork {
 						WallpaperCategoryFilter(
 							selection: $selectedCategory,
-							accentColor: customization.accentColor
+							accentColor: customization.accentColor,
+							counts: wallpaperCategoryCounts,
+							operatorCounts: operatorArtCounts(among: filteredWallpapers),
+							onSelectOperator: { tag in
+								if !committedTags.contains(tag) { committedTags.append(tag) }
+							}
 						)
 					}
 				}
@@ -80,7 +77,6 @@ struct PresetGalleryView: View {
 				PresetGallerySuggestions(
 					destination: destination,
 					avatars: hasSearchQuery ? filteredAvatars : [],
-					wallpapers: hasSearchQuery ? filteredWallpapers : [],
 					wallpaperTerms: hasSearchQuery ? wallpaperTerms : []
 				) { selection in
 					searchText =
@@ -98,7 +94,13 @@ struct PresetGalleryView: View {
 								PresetGalleryEmptyView(
 									text: destination.emptyText, systemImage: "photo")
 							} else {
-								wallpapersGrid(filteredWallpapers)
+								PresetWallpaperGrid(
+									catalog: catalog,
+									accentColor: customization.accentColor,
+									wallpapers: filteredWallpapers,
+									applyingItemID: applyingItemID,
+									onSelect: applyWallpaper
+								)
 							}
 						} else {
 							if filteredAvatars.isEmpty {
@@ -106,7 +108,13 @@ struct PresetGalleryView: View {
 									text: destination.emptyText, systemImage: "person.crop.square"
 								)
 							} else {
-								avatarsGrid(filteredAvatars)
+								PresetAvatarGrid(
+									catalog: catalog,
+									accentColor: customization.accentColor,
+									avatars: filteredAvatars,
+									applyingItemID: applyingItemID,
+									onSelect: applyAvatar
+								)
 							}
 						}
 					}
@@ -149,162 +157,62 @@ struct PresetGalleryView: View {
 			guard !Task.isCancelled, taskDestination == destination else { return }
 			isLoading = false
 		}
-	}
-	private func avatarsGrid(_ filteredAvatars: [PresetAvatar]) -> some View {
-		LazyVGrid(columns: avatarColumns, spacing: 18) {
-			ForEach(filteredAvatars) { avatar in
-				let isApplying = applyingItemID == avatar.id
-				Button {
-					applyAvatar(avatar)
-				} label: {
-					VStack(spacing: 6) {
-						ZStack {
-							CachedPresetImage(
-								catalog: catalog,
-								url: avatar.url,
-								cacheKey: avatar.id,
-								contentMode: .fit,
-								placeholderIcon: "person.crop.square"
-							)
-							.frame(width: 104, height: 104)
-							.background(
-								LinearGradient(
-									colors: [
-										Color(red: 0.16, green: 0.17, blue: 0.19),
-										Color(red: 0.06, green: 0.06, blue: 0.07),
-									],
-									startPoint: .top,
-									endPoint: .bottom
-								)
-							)
-							.clipShape(RoundedRectangle(cornerRadius: 22))
-							if isApplying {
-								ZStack {
-									Color.black.opacity(0.65)
-									ProgressView()
-										.controlSize(.small)
-										.tint(customization.accentColor)
-								}
-								.clipShape(RoundedRectangle(cornerRadius: 22))
-							}
-						}
-						.frame(width: 104, height: 104)
-						.overlay {
-							RoundedRectangle(cornerRadius: 22)
-								.strokeBorder(
-									isApplying
-										? customization.accentColor : Color.white.opacity(0.14),
-									lineWidth: isApplying ? 2.5 : 1.5
-								)
-						}
-						.shadow(
-							color: isApplying
-								? customization.accentColor.opacity(0.5) : Color.black.opacity(0.4),
-							radius: isApplying ? 8 : 5,
-							x: 0,
-							y: 3
-						)
-						Text(avatar.name)
-							.font(.caption.weight(isApplying ? .bold : .medium))
-							.lineLimit(2)
-							.truncationMode(.tail)
-							.foregroundStyle(isApplying ? customization.accentColor : .primary)
-							.frame(maxWidth: 130)
-					}
-					.padding(.vertical, 4)
-					.frame(maxWidth: .infinity)
-					.contentShape(Rectangle())
-				}
-				.buttonStyle(.plain)
-				.keyboardFocusIndicator(in: RoundedRectangle(cornerRadius: 22))
-				.disabled(applyingItemID != nil)
-				.accessibilityLabel(avatar.name)
-				.accessibilityHint(
-					L10n.string(CustomizationStrings.operatorApplyHelp(avatar.name))
-				)
-				.accessibilityValue(
-					isApplying ? Text(L10n.string(CustomizationStrings.applying)) : Text("")
-				)
-			}
+		// Fetched separately from the wallpapers above so the operator roster (needed only to
+		// identify operators among wallpaper tags for the filter's submenu) never delays the
+		// Artwork grid itself from appearing.
+		.task(id: destination) {
+			guard destination == .artwork else { return }
+			let fetchedAvatars = await catalog.fetchAvatars()
+			guard !Task.isCancelled, destination == .artwork else { return }
+			avatars = fetchedAvatars
 		}
 	}
-	private func wallpapersGrid(_ filteredWallpapers: [PresetWallpaper]) -> some View {
-		LazyVGrid(columns: wallpaperColumns, spacing: 14) {
-			ForEach(filteredWallpapers) { wp in
-				let isApplying = applyingItemID == wp.id
-				Button {
-					applyWallpaper(wp)
-				} label: {
-					VStack(alignment: .leading, spacing: 6) {
-						ZStack {
-							CachedPresetImage(
-								catalog: catalog,
-								url: wp.thumbnailURL ?? wp.url,
-								cacheKey: "thumb_\(wp.id)",
-								contentMode: .fill,
-								placeholderIcon: "photo"
-							)
-							.frame(minWidth: 0, maxWidth: .infinity)
-							.frame(height: 105)
-							.clipped()
-							.clipShape(RoundedRectangle(cornerRadius: 10))
-							if isApplying {
-								ZStack {
-									Color.black.opacity(0.68)
-									VStack(spacing: 6) {
-										ProgressView()
-											.controlSize(.regular)
-											.tint(customization.accentColor)
-										Text(L10n.string(CustomizationStrings.applying))
-											.font(.caption2.bold())
-											.foregroundStyle(.white)
-									}
-								}
-								.clipShape(RoundedRectangle(cornerRadius: 10))
-							}
-						}
-						.frame(height: 105)
-						.background(Color.white.opacity(0.05), in: .rect(cornerRadius: 10))
-						Text(wp.displayTitle)
-							.font(.caption.weight(isApplying ? .bold : .medium))
-							.lineLimit(2)
-							.truncationMode(.tail)
-							.foregroundStyle(isApplying ? customization.accentColor : .primary)
-					}
-					.padding(8)
-					.frame(maxWidth: .infinity)
-					.background(
-						isApplying
-							? customization.accentColor.opacity(0.12) : Color.white.opacity(0.03),
-						in: .rect(cornerRadius: 12)
-					)
-					.overlay {
-						RoundedRectangle(cornerRadius: 12)
-							.strokeBorder(
-								isApplying
-									? customization.accentColor : Color.white.opacity(0.07),
-								lineWidth: isApplying ? 2 : 1
-							)
-					}
-					.shadow(
-						color: isApplying ? customization.accentColor.opacity(0.4) : .clear,
-						radius: 8,
-						x: 0,
-						y: 2
-					)
-				}
-				.buttonStyle(.plain)
-				.keyboardFocusIndicator(in: RoundedRectangle(cornerRadius: 12))
-				.disabled(applyingItemID != nil)
-				.accessibilityLabel(wp.displayTitle)
-				.accessibilityHint(
-					L10n.string(CustomizationStrings.wallpaperApplyHelp(wp.displayTitle))
+
+	// How many wallpapers each category filter option would show for the current search text
+	// and committed tag pills, regardless of which category (if any) is currently selected —
+	// so switching categories is an informed choice rather than a guess. `nil` is the "All
+	// Types" option's own total.
+	private var wallpaperCategoryCounts: [WallpaperCategory?: Int] {
+		Dictionary(
+			uniqueKeysWithValues: ([nil] + WallpaperCategory.allCases.map { $0 }).map { category in
+				(
+					category,
+					PresetGallerySearch.wallpapers(
+						matching: searchText, committedTags: committedTags, category: category,
+						in: wallpapers
+					).count
 				)
-				.accessibilityValue(
-					isApplying ? Text(L10n.string(CustomizationStrings.applying)) : Text("")
-				)
-				.help(WallpaperTagCatalog.tags(for: wp.id).joined(separator: ", "))
 			}
+		)
+	}
+
+	// Every operator identifiable among `visibleWallpapers`, with how many of them feature
+	// them — sorted most-featured first. A tag counts as an operator only if it matches a real
+	// operator's name from the character roster, so unrelated tags (locations, event names)
+	// never show up here.
+	private func operatorArtCounts(among visibleWallpapers: [PresetWallpaper]) -> [OperatorArtCount]
+	{
+		guard !avatars.isEmpty else { return [] }
+		let namesByNormalizedTag = Dictionary(
+			avatars.map { (WallpaperSearch.normalized($0.name), $0.name) },
+			uniquingKeysWith: { first, _ in first }
+		)
+		var counts: [String: Int] = [:]
+		for wallpaper in visibleWallpapers {
+			for tag in WallpaperTagCatalog.tags(for: wallpaper.id) {
+				guard namesByNormalizedTag[WallpaperSearch.normalized(tag)] != nil else { continue }
+				counts[tag, default: 0] += 1
+			}
+		}
+		return counts.compactMap { tag, count in
+			namesByNormalizedTag[WallpaperSearch.normalized(tag)].map {
+				OperatorArtCount(tag: tag, displayName: $0, count: count)
+			}
+		}
+		.sorted { lhs, rhs in
+			lhs.count != rhs.count
+				? lhs.count > rhs.count
+				: lhs.displayName.localizedStandardCompare(rhs.displayName) == .orderedAscending
 		}
 	}
 	private func applyAvatar(_ avatar: PresetAvatar) {

--- a/Sources/ArknightsClient/Features/Customization/Presets/UI/WallpaperCategoryFilter.swift
+++ b/Sources/ArknightsClient/Features/Customization/Presets/UI/WallpaperCategoryFilter.swift
@@ -5,20 +5,51 @@ import SwiftUI
 struct WallpaperCategoryFilter: View {
 	@Binding var selection: WallpaperCategory?
 	let accentColor: Color
+	/// Wallpaper counts for each category (and, under the `nil` key, the total across every
+	/// category) among whatever's currently in play — the active search text and tag pills —
+	/// so a count reflects what picking that option would actually show, not the whole catalog.
+	let counts: [WallpaperCategory?: Int]
+	/// Every operator identified among the currently shown wallpapers, most-featured first —
+	/// picking one commits it as an exact-tag search pill, the same as typing its name would.
+	let operatorCounts: [OperatorArtCount]
+	let onSelectOperator: (String) -> Void
 
 	var body: some View {
 		GlassMenuPicker(
 			selection: $selection,
 			options: options,
-			accentColor: accentColor
+			accentColor: accentColor,
+			listTitle: { category in
+				L10n.string(
+					CustomizationStrings.wallpaperFilterOption(
+						title(for: category), count: counts[category] ?? 0))
+			},
+			trailingMenuItems: {
+				guard !operatorCounts.isEmpty else { return AnyView(EmptyView()) }
+				return AnyView(
+					Menu(L10n.string(CustomizationStrings.wallpaperFilterOperators)) {
+						ForEach(operatorCounts) { entry in
+							Button(
+								L10n.string(
+									CustomizationStrings.wallpaperFilterOption(
+										entry.displayName, count: entry.count))
+							) {
+								onSelectOperator(entry.tag)
+							}
+						}
+					}
+				)
+			}
 		)
 		.accessibilityLabel(Text(L10n.string(CustomizationStrings.wallpaperFilterLabel)))
 	}
 
 	private var options: [(value: WallpaperCategory?, title: String)] {
-		[(nil, L10n.string(CustomizationStrings.wallpaperFilterAll))]
-			+ WallpaperCategory.allCases.map {
-				($0, L10n.string(CustomizationStrings.wallpaperCategory($0)))
-			}
+		([nil] + WallpaperCategory.allCases.map { $0 }).map { ($0, title(for: $0)) }
+	}
+
+	private func title(for category: WallpaperCategory?) -> String {
+		category.map { L10n.string(CustomizationStrings.wallpaperCategory($0)) }
+			?? L10n.string(CustomizationStrings.wallpaperFilterAll)
 	}
 }

--- a/Sources/ArknightsClient/Resources/Customization.xcstrings
+++ b/Sources/ArknightsClient/Resources/Customization.xcstrings
@@ -359,6 +359,38 @@
         "en": { "stringUnit": { "state": "translated", "value": "Wallpaper type" } }
       }
     },
+    "customization.gallery.wallpaper.filter.operators": {
+      "comment": "Wallpaper filter submenu title listing every operator who appears in an official wallpaper",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Operatoren" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Operators" } }
+      }
+    },
+    "customization.gallery.wallpaper.filter.optionWithCount": {
+      "comment": "Wallpaper category filter choice with the number of wallpapers it matches; arguments are the category title and its count",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "%@ (%lld)" } },
+        "en": { "stringUnit": { "state": "translated", "value": "%@ (%lld)" } }
+      }
+    },
+    "customization.gallery.wallpaper.hoverArtist": {
+      "comment": "Wallpaper thumbnail hover tooltip line naming the artist; argument is their name",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Künstler: %@" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Artist: %@" } }
+      }
+    },
+    "customization.gallery.wallpaper.hoverTags": {
+      "comment": "Wallpaper thumbnail hover tooltip line listing its curated tags; argument is the comma-separated list",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Tags: %@" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Tags: %@" } }
+      }
+    },
     "customization.gallery.wallpaper.type.celebration": {
       "comment": "Wallpaper category for anniversaries, celebrations, and livestreams",
       "extractionState": "manual",

--- a/Sources/ArknightsClient/Shared/UI/Components/Settings/SettingsComponents.swift
+++ b/Sources/ArknightsClient/Shared/UI/Components/Settings/SettingsComponents.swift
@@ -199,6 +199,13 @@ struct GlassMenuPicker<Value: Hashable>: View {
 	let options: [(value: Value, title: String)]
 	let accentColor: Color
 	var isDisabled = false
+	/// Overrides an option's displayed text inside the open menu only, leaving `title` as the
+	/// collapsed button's label — lets a caller show detail (e.g. a result count) that's only
+	/// worth the width once the list is actually open.
+	var listTitle: (Value) -> String? = { _ in nil }
+	/// Additional menu content appended after the plain option list — e.g. a submenu that
+	/// doesn't itself change `selection`. Defaults to nothing, so existing callers are unaffected.
+	var trailingMenuItems: () -> AnyView = { AnyView(EmptyView()) }
 
 	var body: some View {
 		Menu {
@@ -206,13 +213,15 @@ struct GlassMenuPicker<Value: Hashable>: View {
 				Button {
 					selection.wrappedValue = option.value
 				} label: {
+					let title = listTitle(option.value) ?? option.title
 					if option.value == selection.wrappedValue {
-						Label(option.title, systemImage: "checkmark")
+						Label(title, systemImage: "checkmark")
 					} else {
-						Text(option.title)
+						Text(title)
 					}
 				}
 			}
+			trailingMenuItems()
 		} label: {
 			HStack(spacing: 5) {
 				Text(currentTitle)


### PR DESCRIPTION
## Summary

A few small improvements to browsing the Artwork gallery:

The category filter (All Types, Story, Commemorative, Celebration, Holiday) now shows how many wallpapers each choice matches once the list is open — the button itself stays uncluttered, showing counts only inside the dropdown.

The same dropdown now has an **Operators** submenu, listing every operator who appears in official wallpapers, sorted by how often they show up. Picking one filters the gallery to their art, same as typing their name.

<img width="417" height="441" alt="image" src="https://github.com/user-attachments/assets/70fc9d74-aef3-4e74-85a5-53334a15637a" />

<hr/>

Hovering a wallpaper now shows its artist and curated tags, not just tags.
<img width="449" height="175" alt="image" src="https://github.com/user-attachments/assets/966b1c6d-bf53-4e80-a258-1576d2fbc1e6" />

<hr/>

Search suggestion chips are limited to tag/word completions — no more chips repeating a whole wallpaper's title, which the grid already shows directly below.
<img width="739" height="483" alt="image" src="https://github.com/user-attachments/assets/3701f31f-a471-44f8-a7da-951bd1cb3494" />



## Why this matters

Finding wallpapers for a specific operator, or getting a sense of how many wallpapers exist for a category or character, previously meant scrolling and guessing. This makes both a one-click, informed choice, and gives more context on hover without leaving the grid.

---

<details>
<summary>Technical detail</summary>

- `WallpaperCategoryFilter` now takes `counts` (per-category totals for the current search/tag context) and `operatorCounts` (`OperatorArtCount`, derived by cross-referencing wallpaper tags against the real operator roster from `character_table.json` so only genuine operator names ever appear, never unrelated tags like locations or event names).
- `GlassMenuPicker` (shared by several Settings pickers) gained two backward-compatible additions: `listTitle` to override an option's text inside the open menu only (leaving the collapsed button's label unchanged), and `trailingMenuItems` for appending extra content — like the Operators submenu — after the plain option list. Both default to a no-op, so every other caller is unaffected.
- The wallpaper and operator grids were extracted into standalone `PresetWallpaperGrid`/`PresetAvatarGrid` components, fed explicit parameters rather than reaching into `PresetGalleryView`'s private state — matching the same pattern `PresetGallerySearchBar` already uses, so `PresetGalleryView`'s state stays private.
- The operator roster is fetched in a separate `.task` alongside the wallpapers fetch so it never delays the Artwork grid itself from appearing.

</details>

## Test plan

- [x] `just check` — 343/343 Swift tests pass.
- [x] Built the real release app and manually verified: category counts appear only inside the open dropdown; the Operators submenu lists operators sorted by count and filters correctly on selection; the hover tooltip shows artist, tags, and description; search suggestions only ever show tag completions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)