### PR TITLE
feat: add launch splash animation for artwork load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Wallpaper counts to the Artwork gallery's category filter, plus an Operators submenu listing every operator featured in official wallpapers, sorted by how many they appear in (Thanks to @darkwebdev, #73).
 - The artist and curated tags to a wallpaper's hover tooltip in the Artwork gallery (Thanks to @darkwebdev, #73).
+- Added a brief launch animation — two progress bars closing in from each edge with a percentage readout — shown while the launcher's artwork loads, replacing an abrupt cut from a plain placeholder to the real artwork.
 
 ### Changed
 

--- a/Sources/ArknightsClient/Features/Customization/State/CustomizationController+Artwork.swift
+++ b/Sources/ArknightsClient/Features/Customization/State/CustomizationController+Artwork.swift
@@ -143,6 +143,7 @@ extension CustomizationController {
 			)
 		}
 		await restoreOfficialLogo(for: region).value
+		markInitialArtworkLoadComplete()
 	}
 
 	/// Clears any previous region's wordmark before a refresh can load the selected region's asset.

--- a/Sources/ArknightsClient/Features/Customization/State/CustomizationController.swift
+++ b/Sources/ArknightsClient/Features/Customization/State/CustomizationController.swift
@@ -26,6 +26,9 @@ final class CustomizationController {
 		didSet { updateThemeColor() }
 	}
 	var officialLogo: NSImage?
+	/// Set once `restoreInitialArtwork(for:)` finishes, whether or not it actually found any
+	/// artwork to show — the launch splash stays up until this flips, then never again.
+	private(set) var hasCompletedInitialArtworkLoad = false
 	private(set) var hasCustomAppIcon = false
 	private(set) var hasCustomGameIcon = false
 	var dynamicThemeHue: Double?
@@ -57,6 +60,10 @@ final class CustomizationController {
 
 	func setHasPersistedCustomArtwork(_ value: Bool) {
 		hasPersistedCustomArtwork = value
+	}
+
+	func markInitialArtworkLoadComplete() {
+		hasCompletedInitialArtworkLoad = true
 	}
 
 	func setHasCustomAppIcon(_ value: Bool) {

--- a/Sources/ArknightsClient/Features/Launcher/Home/ContentView.swift
+++ b/Sources/ArknightsClient/Features/Launcher/Home/ContentView.swift
@@ -78,10 +78,16 @@ struct ContentView: View {
 					showFailureDetails: showFailureDetails)
 			}
 			.id(model.settings.appLanguage)
+			// Kept in the hierarchy (just faded out) rather than removed via `if`, so it can
+			// actually observe `isComplete` flip instead of being torn down before it does.
+			LauncherSplashView(isComplete: model.customization.hasCompletedInitialArtworkLoad)
+				.opacity(model.customization.hasCompletedInitialArtworkLoad ? 0 : 1)
+				.allowsHitTesting(!model.customization.hasCompletedInitialArtworkLoad)
 		}
 		.background(Color.black)
 		.preferredColorScheme(.dark)
 		.animation(themeAnimation, value: model.customization.dynamicThemeHue)
+		.animation(splashAnimation, value: model.customization.hasCompletedInitialArtworkLoad)
 		.overlay {
 			if onboardingIsPresentable {
 				OnboardingView(
@@ -336,4 +342,8 @@ struct ContentView: View {
 	}
 
 	private var themeAnimation: Animation? { reduceMotion ? nil : .easeInOut(duration: 0.3) }
+	private var splashAnimation: Animation? {
+		reduceMotion ? nil : .easeInOut(duration: splashFadeDuration)
+	}
+	private var splashFadeDuration: TimeInterval { reduceMotion ? 0 : 0.5 }
 }

--- a/Sources/ArknightsClient/Features/Launcher/Home/LauncherSplashView.swift
+++ b/Sources/ArknightsClient/Features/Launcher/Home/LauncherSplashView.swift
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MPL-2.0
+
+import SwiftUI
+
+/// Shown over the whole window from launch until the initial artwork restore completes, so the
+/// launcher opens on a deliberate brand moment instead of an abrupt cut from a dark placeholder
+/// to the real artwork a couple of seconds later. Two thin bars grow inward from each edge with
+/// their percentage riding above the leading tip, meeting at the center exactly as the real load
+/// finishes.
+struct LauncherSplashView: View {
+	let isComplete: Bool
+	@State private var progress: Double = 0
+	// `isComplete` is a plain `let`, so the long-running climb/snap tasks below would otherwise
+	// only ever see the frozen value from whenever `.task` first started — `@State` storage
+	// persists independently of that and is what a running task can actually observe live.
+	@State private var completed = false
+
+	private static let gold = Color(red: 0.95, green: 0.78, blue: 0.2)
+	private static let barHeight: CGFloat = 3
+	private static let labelGap: CGFloat = 22
+	// How far the fake climb gets on its own before real completion snaps the rest of the
+	// way — never claims 100% before the load has actually finished. If the real load finishes
+	// sooner than this, the snap just starts from wherever the climb had actually reached.
+	private static let fakeClimbCeiling = 0.92
+	private static let fakeClimbDuration: TimeInterval = 0.9
+	private static let completionSnapDuration: TimeInterval = 0.25
+	// Every step is a plain, unanimated state assignment — deliberately not `withAnimation`.
+	// SwiftUI's animation system only diffs the start/end of a transaction and lets non-
+	// animatable content (the label text, which of the three labels is showing) jump straight
+	// to its target while animatable properties (bar width, label position) interpolate on
+	// their own — which visibly desyncs the bars from the percentage they're supposed to match.
+	// Stepping the state by hand keeps every dependent value reading the exact same `progress`
+	// on every real render, so nothing can drift apart.
+	private static let stepInterval: TimeInterval = 1.0 / 30
+
+	var body: some View {
+		GeometryReader { proxy in
+			let half = proxy.size.width / 2
+			let barWidth = half * progress
+			let midY = proxy.size.height / 2
+			let sidePercentageText = "\(min(99, Int(progress * 100)))%"
+			let isDone = progress >= 1
+			ZStack {
+				Color.black
+				bar(width: barWidth).position(x: barWidth / 2, y: midY)
+				bar(width: barWidth)
+					.position(x: proxy.size.width - barWidth / 2, y: midY)
+				// All three labels stay mounted the whole time — only their opacity changes —
+				// so the swap from two side labels to one centered "100%" is a plain property
+				// change on existing views, not an `if`/`else` identity swap that would need
+				// its own cross-fade.
+				label(sidePercentageText)
+					.opacity(isDone ? 0 : 1)
+					.position(x: barWidth, y: midY - Self.labelGap)
+				label(sidePercentageText)
+					.opacity(isDone ? 0 : 1)
+					.position(x: proxy.size.width - barWidth, y: midY - Self.labelGap)
+				label("100%")
+					.opacity(isDone ? 1 : 0)
+					.position(x: half, y: midY - Self.labelGap)
+			}
+		}
+		.ignoresSafeArea()
+		.accessibilityHidden(true)
+		.task { await climb() }
+		.onChange(of: isComplete) { _, complete in
+			guard complete else { return }
+			completed = true
+			Task { await snapToComplete() }
+		}
+	}
+
+	private func bar(width: CGFloat) -> some View {
+		Rectangle().fill(Self.gold).frame(width: width, height: Self.barHeight)
+	}
+
+	private func label(_ text: String) -> some View {
+		Text(verbatim: text)
+			.font(.system(size: 15, weight: .medium))
+			.foregroundStyle(Self.gold)
+	}
+
+	// Driven by real elapsed time rather than a fixed step count: during launch the main actor
+	// is busy with window/runtime setup, so individual sleeps routinely take longer than their
+	// nominal duration, and a step-counted climb falls badly behind wall-clock time — landing
+	// well short of its ceiling by the time the real load actually finishes.
+	private func climb() async {
+		guard !completed else { return }
+		let start = Date()
+		while !completed {
+			try? await Task.sleep(for: .seconds(Self.stepInterval))
+			guard !completed else { return }
+			let fraction = min(1, Date().timeIntervalSince(start) / Self.fakeClimbDuration)
+			progress = Self.fakeClimbCeiling * fraction
+			if fraction >= 1 { return }
+		}
+	}
+
+	private func snapToComplete() async {
+		let start = Date()
+		let startProgress = progress
+		while true {
+			try? await Task.sleep(for: .seconds(Self.stepInterval))
+			let fraction = min(1, Date().timeIntervalSince(start) / Self.completionSnapDuration)
+			progress = startProgress + (1 - startProgress) * fraction
+			if fraction >= 1 {
+				progress = 1
+				return
+			}
+		}
+	}
+}

--- a/Sources/ArknightsClient/Features/Launcher/State/LauncherViewModel.swift
+++ b/Sources/ArknightsClient/Features/Launcher/State/LauncherViewModel.swift
@@ -197,6 +197,9 @@ final class LauncherViewModel {
 					guard let self else { return }
 					_ = await customization.loadCustomAppIcon()
 					await loadDeveloperArtwork()
+					// The launch splash otherwise never dismisses in developer scenarios, since
+					// they bypass restoreInitialArtwork(for:) (the real startup path) entirely.
+					customization.markInitialArtworkLoadComplete()
 				}
 				Task { [log] in await log.info("Developer simulation started") }
 				return

--- a/Tests/ArknightsClientTests/Customization/CustomizationControllerTests.swift
+++ b/Tests/ArknightsClientTests/Customization/CustomizationControllerTests.swift
@@ -22,6 +22,16 @@ struct CustomizationControllerTests {
 
 		#expect(fixture.controller.heroArtwork != nil)
 		#expect(fixture.controller.activeThemeCacheKey?.hasPrefix("custom.") == true)
+		#expect(fixture.controller.hasCompletedInitialArtworkLoad)
+	}
+	@Test
+	func initialRestoreCompletesEvenWithoutAnyArtworkToShow() async throws {
+		let fixture = makeCustomizationController()
+
+		await fixture.controller.restoreInitialArtwork(for: .global)
+
+		#expect(fixture.controller.heroArtwork == nil)
+		#expect(fixture.controller.hasCompletedInitialArtworkLoad)
 	}
 	@Test
 	func newerArtworkSelectionRejectsAnOlderDelayedRead() async throws {
@@ -91,7 +101,9 @@ struct CustomizationControllerTests {
 		try Data("official".utf8).write(
 			to: fixture.paths.artworkCache.appending(path: "active-global.txt"))
 
-		let restore = Task { await fixture.controller.restoreInitialArtwork(for: .global) }
+		let restore = Task {
+			await fixture.controller.restoreInitialArtwork(for: .global)
+		}
 		await loader.waitForRequestCount(1)
 		let mutation = Task {
 			await fixture.controller.applyDirectCustomArtwork(data: customData)


### PR DESCRIPTION
## What changed

The launcher used to open on a plain dark placeholder and then cut abruptly to the real artwork a second or two later. This adds a brief launch animation — two thin gold bars closing in from each screen edge with a percentage readout in between — shown while the artwork loads, fading smoothly into the artwork once it's ready.

## Test plan

- [x] `just check` passes (344 tests, lint/format clean)
- [x] Built and launched the app; splash appears on launch and fades into artwork once loading finishes
- [x] Manually verified on a fresh install with no cached artwork
- [x] Manually verified across different launcher window sizes


https://github.com/user-attachments/assets/06862052-27d7-4ebc-a8b6-7345e2c5d0d6


<details>
<summary>Implementation notes</summary>

`LauncherSplashView` renders the two bars and percentage labels over the whole window from launch until `CustomizationController.restoreInitialArtwork(for:)` finishes (tracked via a new `hasCompletedInitialArtworkLoad` flag), then fades out. Progress is paced from actual elapsed wall-clock time rather than a step counter, so the animation stays accurate even if individual timer ticks get delayed by other startup work competing for the main actor. All percentage labels stay mounted the whole time with only their opacity toggled, avoiding an implicit SwiftUI cross-fade between differently-identified views at completion.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)